### PR TITLE
Cleanup and Reduce memory use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-/target
+target/
+*.iml
+.idea/

--- a/LGPL2.1-template.txt
+++ b/LGPL2.1-template.txt
@@ -1,0 +1,17 @@
+${project.name}
+${project.description}
+Copyright (C) ${project.inceptionYear} ${organization}
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation; either version 2.1
+of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this library; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,504 @@
+		  GNU LESSER GENERAL PUBLIC LICENSE
+		       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+			    Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+  
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+			    NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+		     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -4,20 +4,50 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>ro.kuberam.libs.java</groupId>
-	<artifactId>crypto</artifactId>
-	<version>1.4-SNAPSHOT</version>
-	<name>Library for EXPath Cryptographic Module</name>
-	<url>http://kuberam.ro/specs/expath/crypto/crypto.html</url>
-
 	<prerequisites>
 		<maven>${mavenVersion}</maven>
 	</prerequisites>
 
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+		<relativePath />
+	</parent>
+
+	<groupId>ro.kuberam.libs.java</groupId>
+	<artifactId>crypto</artifactId>
+	<version>1.4-SNAPSHOT</version>
+
+	<name>EXPath Cryptographic Module</name>
+	<description>Java Library providing an EXPath Cryptographic Module</description>
+	<url>http://kuberam.ro/specs/expath/crypto/crypto.html</url>
+	<inceptionYear>2015</inceptionYear>
+
+	<organization>
+		<name>Kuberam</name>
+		<url>http://kuberam.ro</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>GNU Lesser General Public License version 2.1</name>
+			<url>https://opensource.org/licenses/LGPL-2.1</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<connection>scm:git:https://github.com/claudius108/crypto-java-lib.git</connection>
+		<developerConnection>scm:git:https://github.com/claudius108/crypto-java-lib.git</developerConnection>
+		<url>scm:git:https://github.com/claudius108/crypto-java-lib.git</url>
+	</scm>
+
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<project.build.source>1.8</project.build.source>
+		<project.build.target>1.8</project.build.target>
+
 		<mavenVersion>3.3.3</mavenVersion>
 	</properties>
 
@@ -56,5 +86,160 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>3.0</version>
+				<configuration>
+					<header>LGPL2.1-template.txt</header>
+					<failIfMissing>true</failIfMissing>
+					<aggregate>true</aggregate>
+					<strictCheck>true</strictCheck>
+					<properties>
+						<owner>${project.organization.name}</owner>
+						<organization>${project.organization.name}</organization>
+						<email>exit-open@lists.sourceforge.net</email>
+						<url>${project.organization.url}</url>
+					</properties>
+					<excludes>
+						<exclude>pom.xml</exclude>
+						<exclude>README.md</exclude>
+						<exclude>LICENSE</exclude>
+						<exclude>crypto-java-lib deploy.launch</exclude>
+						<exclude>src/main/java/ro/kuberam/libs/java/crypto/changelog.txt</exclude>
+						<exclude>src/main/resources/ro/kuberam/libs/java/crypto/lib.properties</exclude>
+						<exclude>src/test/resources/**/*.txt</exclude>
+						<exclude>src/test/resources/**/*.xml</exclude>
+						<exclude>**/*.cer</exclude>
+						<exclude>**/*.ks</exclude>
+						<exclude>**/*.key</exclude>
+						<exclude>**/*.pub</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.0.2</version>
+				<executions>
+					<execution>
+						<id>analyze</id>
+						<goals>
+							<goal>analyze-only</goal>
+						</goals>
+						<configuration>
+							<failOnWarning>true</failOnWarning>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.7.0</version>
+				<configuration>
+					<source>${project.build.source}</source>
+					<target>${project.build.target}</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>com.code54.mojo</groupId>
+				<artifactId>buildversion-plugin</artifactId>
+				<version>1.0.3</version>
+				<executions>
+					<execution>
+						<phase>validate</phase>
+						<goals>
+							<goal>set-properties</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>3.0.2</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+						<manifestEntries>
+							<Build-Tag>${build-tag}</Build-Tag>
+							<Git-Commit>${build-commit}</Git-Commit>
+							<Git-Commit-Abbrev>${build-commit-abbrev}</Git-Commit-Abbrev>
+							<Build-Version>${build-version}</Build-Version>
+							<Build-Timestamp>${build-tstamp}</Build-Timestamp>
+							<Source-Repository>${project.scm.connection}</Source-Repository>
+							<Description>${project.description}</Description>
+							<Implementation-URL>${project.url}</Implementation-URL>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<!-- Attach source jars -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+						<manifestEntries>
+							<Build-Tag>${build-tag}</Build-Tag>
+							<Git-Commit>${build-commit}</Git-Commit>
+							<Git-Commit-Abbrev>${build-commit-abbrev}</Git-Commit-Abbrev>
+							<Build-Version>${build-version}</Build-Version>
+							<Build-Timestamp>${build-tstamp}</Build-Timestamp>
+							<Source-Repository>${project.scm.connection}</Source-Repository>
+							<Description>${project.description}</Description>
+							<Implementation-URL>${project.url}</Implementation-URL>
+						</manifestEntries>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.6</version>
+				<configuration>
+					<useAgent>true</useAgent>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<mavenExecutorId>forked-path</mavenExecutorId> <!-- avoid a bug with GPG plugin hanging http://jira.codehaus.org/browse/MGPG-9 -->
+					<autoVersionSubmodules>true</autoVersionSubmodules>
+					<tagNameFormat>@{project.version}</tagNameFormat>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>clojars.org</id>
+			<url>http://clojars.org/repo</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>ro.kuberam.libs.java</groupId>
 	<artifactId>crypto</artifactId>
-	<version>1.3.2</version>
+	<version>1.4-SNAPSHOT</version>
 	<name>Library for EXPath Cryptographic Module</name>
 	<url>http://kuberam.ro/specs/expath/crypto/crypto.html</url>
 
@@ -23,9 +23,24 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>3.0.2</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -33,11 +48,6 @@
 			<artifactId>junit-tests</artifactId>
 			<version>0.1</version>
 			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.uuid</groupId>

--- a/src/main/java/ro/kuberam/libs/java/crypto/ErrorMessages.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ErrorMessages.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 public class ErrorMessages {

--- a/src/main/java/ro/kuberam/libs/java/crypto/ErrorMessages.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ErrorMessages.java
@@ -1,20 +1,21 @@
 package ro.kuberam.libs.java.crypto;
-      
+
 public class ErrorMessages {
-      public static String error_unknownAlgorithm = "crypto:unknown-algorithm: The specified algorithm is not supported.";
-      public static String error_signatureType = "crypto:signature-type: The specified signature type is not supported.";
-      public static String error_readKeystore = "crypto:unreadable-keystore: I/O error while reading keystore, or the password is incorrect.";
-      public static String error_deniedKeystore = "crypto:denied-keystore: Permission denied to read keystore.";
-      public static String error_keystoreUrl = "crypto:keystore-url: The keystore URL is invalid.";
-      public static String error_keystoreType = "crypto:keystore-type: The keystore type is not supported.";
-      public static String error_aliasKey = "crypto:alias-key: Cannot find key for alias in given keystore.";
-      public static String error_sigElem = "crypto:signature-element: Cannot find Signature element.";
-      public static String error_noPadding = "crypto:inexistent-padding: No such padding.";
-      public static String error_incorrectPadding = "crypto:incorrect-padding: Incorrect padding.";
-      public static String error_encType = "crypto:encryption-type: The encryption type is not supported.";
-      public static String error_cryptoKey = "crypto:invalid-crypto-key: The cryptographic key is invalid.";
-      public static String error_blockSize = "crypto:block-size: Illegal block size.";
-      public static String error_decryptionType = "crypto:decryption-type: The decryption type is not supported.";
-      public static String error_noProvider = "crypto:no-provider: The provider is not set.";
-      public static String error_outputFormat = "crypto.output-format: The output format is not supported.";
+    public static final String error_unknownAlgorithm = "crypto:unknown-algorithm: The specified algorithm is not supported.";
+    public static final String error_signatureType = "crypto:signature-type: The specified signature type is not supported.";
+    public static final String error_readKeystore = "crypto:unreadable-keystore: I/O error while reading keystore, or the password is incorrect.";
+    public static final String error_deniedKeystore = "crypto:denied-keystore: Permission denied to read keystore.";
+    public static final String error_keystoreUrl = "crypto:keystore-url: The keystore URL is invalid.";
+    public static final String error_keystoreType = "crypto:keystore-type: The keystore type is not supported.";
+    public static final String error_aliasKey = "crypto:alias-key: Cannot find key for alias in given keystore.";
+    public static final String error_invalidKey = "crypto:invalid-key: The specified key is invalid.";
+    public static final String error_sigElem = "crypto:signature-element: Cannot find Signature element.";
+    public static final String error_noPadding = "crypto:inexistent-padding: No such padding.";
+    public static final String error_incorrectPadding = "crypto:incorrect-padding: Incorrect padding.";
+    public static final String error_encType = "crypto:encryption-type: The encryption type is not supported.";
+    public static final String error_cryptoKey = "crypto:invalid-crypto-key: The cryptographic key is invalid.";
+    public static final String error_blockSize = "crypto:block-size: Illegal block size.";
+    public static final String error_decryptionType = "crypto:decryption-type: The decryption type is not supported.";
+    public static final String error_noProvider = "crypto:no-provider: The provider is not set.";
+    public static final String error_outputFormat = "crypto.output-format: The output format is not supported.";
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/ExpathCryptoModule.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ExpathCryptoModule.java
@@ -1,21 +1,21 @@
-/*
- *  Copyright (C) 2011 Claudius Teodorescu
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package ro.kuberam.libs.java.crypto;
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/ExpathCryptoModule.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ExpathCryptoModule.java
@@ -21,57 +21,59 @@ package ro.kuberam.libs.java.crypto;
 
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 /**
  * Implements the module definition.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 public class ExpathCryptoModule {
-	
+
 //	static {
 //		java.security.Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
 //	}
 //	
 //	public final static Provider defaultProvider = java.security.Security.getProvider("BC");
 
-	public final static Properties libProperties = new Properties();
-	static {
-		InputStream propertiesIs;
-		try {
-			propertiesIs = ExpathCryptoModule.class.getResourceAsStream("lib.properties");
-			libProperties.load(propertiesIs);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
-	public final static String NAMESPACE_URI = "http://expath.org/ns/crypto";
-	public final static String PREFIX = "crypto";
-	public final static String VERSION = libProperties.getProperty("lib-version");
-	public final static String MODULE_DESCRIPTION = "A module for providing cryptographic services.";
-	public final static String MODULE_NAME = "EXPath Cryptographic";
-	
-	public final static HashMap<String, String> javaStandardAlgorithmNames = new HashMap<String, String>();
-	static {
-		javaStandardAlgorithmNames.put("HMAC-MD5", "HmacMD5");
-		javaStandardAlgorithmNames.put("HMAC-SHA-1", "HmacSHA1");
-		javaStandardAlgorithmNames.put("HMAC-SHA-256", "HmacSHA256");
-		javaStandardAlgorithmNames.put("HMAC-SHA-384", "HmacSHA384");
-		javaStandardAlgorithmNames.put("HMAC-SHA-512", "HmacSHA512");
-	}	
+    public static final Properties libProperties = new Properties();
 
-	// crypto:generate-signature() description
-	public final static String canonicalization_algorithm = "The canonicalization algorithm applied to the SignedInfo element prior to performing signature calculations. Possible values are: 'exclusive', 'exclusive-with-comments', 'inclusive', and 'inclusive-with-comments'. The default value is 'inclusive-with-comments'.";
-	public final static String DIGEST_ALGORITHM = "The digest algorithm to be applied to the signed object. Possible values are: 'SHA1', 'SHA256', and 'SHA512'. The default value is 'SHA1'.";
-	public final static String SIGNATURE_ALGORITHM = "The algorithm used for signature generation and validation. Possible values are: 'DSA_SHA1', and 'RSA_SHA1'. The default value is 'RSA_SHA1'.";
-	public final static String SIGNATURE_TYPE = "The method used for signing the content of signature. Possible values are: 'enveloping', 'enveloped', and 'detached'. The default value is 'enveloped'.";
-	public final static String digitalCertificateDetailsDescription = "Details about the digital certificate to be used for signing the input document or document subset."
-			+ " The structure of this parameter is as follows (this is an example): "
-			+ "<digital-certificate>"
-			+ "<keystore-type>JKS</keystore-type>"
-			+ "<keystore-password>ab987c</keystore-password>"
-			+ "<key-alias>eXist</key-alias>"
-			+ "<private-key-password>kpi135</private-key-password>"
-			+ "<keystore-uri>/db/mykeystoreEXist.ks</keystore-uri>" + "</digital-certificate>.";	
+    static {
+        try (final InputStream propertiesIs = ExpathCryptoModule.class.getResourceAsStream("lib.properties")) {
+            libProperties.load(propertiesIs);
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static final String NAMESPACE_URI = "http://expath.org/ns/crypto";
+    public static final String PREFIX = "crypto";
+    public static final String VERSION = libProperties.getProperty("lib-version");
+    public static final String MODULE_DESCRIPTION = "A module for providing cryptographic services.";
+    public static final String MODULE_NAME = "EXPath Cryptographic";
+
+    public static final Map<String, String> javaStandardAlgorithmNames = new HashMap<>();
+
+    static {
+        javaStandardAlgorithmNames.put("HMAC-MD5", "HmacMD5");
+        javaStandardAlgorithmNames.put("HMAC-SHA-1", "HmacSHA1");
+        javaStandardAlgorithmNames.put("HMAC-SHA-256", "HmacSHA256");
+        javaStandardAlgorithmNames.put("HMAC-SHA-384", "HmacSHA384");
+        javaStandardAlgorithmNames.put("HMAC-SHA-512", "HmacSHA512");
+    }
+
+    // crypto:generate-signature() description
+    public static final String canonicalization_algorithm = "The canonicalization algorithm applied to the SignedInfo element prior to performing signature calculations. Possible values are: 'exclusive', 'exclusive-with-comments', 'inclusive', and 'inclusive-with-comments'. The default value is 'inclusive-with-comments'.";
+    public static final String DIGEST_ALGORITHM = "The digest algorithm to be applied to the signed object. Possible values are: 'SHA1', 'SHA256', and 'SHA512'. The default value is 'SHA1'.";
+    public static final String SIGNATURE_ALGORITHM = "The algorithm used for signature generation and validation. Possible values are: 'DSA_SHA1', and 'RSA_SHA1'. The default value is 'RSA_SHA1'.";
+    public static final String SIGNATURE_TYPE = "The method used for signing the content of signature. Possible values are: 'enveloping', 'enveloped', and 'detached'. The default value is 'enveloped'.";
+    public static final String digitalCertificateDetailsDescription = "Details about the digital certificate to be used for signing the input document or document subset."
+            + " The structure of this parameter is as follows (this is an example): "
+            + "<digital-certificate>"
+            + "<keystore-type>JKS</keystore-type>"
+            + "<keystore-password>ab987c</keystore-password>"
+            + "<key-alias>eXist</key-alias>"
+            + "<private-key-password>kpi135</private-key-password>"
+            + "<keystore-uri>/db/mykeystoreEXist.ks</keystore-uri>" + "</digital-certificate>.";
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/ModuleDescription.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ModuleDescription.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/ModuleDescription.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/ModuleDescription.java
@@ -3,13 +3,13 @@ package ro.kuberam.libs.java.crypto;
 
 /**
  * Module description.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
- */      
+ */
 public class ModuleDescription {
-      public final static String VERSION = "1.1";
-      public final static String NAMESPACE_URI = "";
-      public final static String PREFIX = "";
-      public final static String MODULE_NAME = "Library for EXPath Cryptographic Module";
-      public final static String MODULE_DESCRIPTION = "A ";
+    public static final String VERSION = "1.1";
+    public static final String NAMESPACE_URI = "";
+    public static final String PREFIX = "";
+    public static final String MODULE_NAME = "Library for EXPath Cryptographic Module";
+    public static final String MODULE_DESCRIPTION = "A ";
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/Parameters.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/Parameters.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 import javax.xml.crypto.dsig.CanonicalizationMethod;

--- a/src/main/java/ro/kuberam/libs/java/crypto/Parameters.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/Parameters.java
@@ -6,98 +6,105 @@ import javax.xml.crypto.dsig.SignatureMethod;
 import javax.xml.crypto.dsig.Transform;
 
 public class Parameters {
-	private String canonicalizationAlgorithm = CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS;
-	private String[] canonicalizationAlgorithmValues = new String[] { "exclusive",
-			"exclusive-with-comments", "inclusive", "inclusive-with-comments" };
-	private String digestAlgorithm = DigestMethod.SHA1;
-	private String[] digestAlgorithmValues = new String[] { "SHA1", "SHA256", "SHA512" };
-	private String signatureAlgorithm = SignatureMethod.RSA_SHA1;
-	private String[] signatureAlgorithmValues = new String[] { "DSA_SHA1", "RSA_SHA1" };
-	private String signatureNamespacePrefix = "dsig";
-	private String signatureType = "enveloped";
-	private String[] signatureTypeValues = new String[] { "enveloping", "enveloped", "detached" };
+    private String canonicalizationAlgorithm = CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS;
+    private static final String[] CANONICALIZATION_ALGORITHM_VALUES = {"exclusive",
+            "exclusive-with-comments", "inclusive", "inclusive-with-comments"};
+    private String digestAlgorithm = DigestMethod.SHA1;
+    private static final String[] DIGEST_ALGORITHM_VALUES = {"SHA1", "SHA256", "SHA512"};
+    private String signatureAlgorithm = SignatureMethod.RSA_SHA1;
+    private static final String[] SIGNATURE_ALGORITHM_VALUES = {"DSA_SHA1", "RSA_SHA1"};
+    private String signatureNamespacePrefix = "dsig";
+    private String signatureType = "enveloped";
+    private static final String[] SIGNATURE_TYPE_VALUES = {"enveloping", "enveloped", "detached"};
 
-	public Parameters() {
-	}
+    public String getCanonicalizationAlgorithm() {
+        return canonicalizationAlgorithm;
+    }
 
-	public String getCanonicalizationAlgorithm() {
-		return canonicalizationAlgorithm;
-	}
+    public void setCanonicalizationAlgorithm(final String canonicalizationAlgorithm) throws Exception {
+        if (!contains(CANONICALIZATION_ALGORITHM_VALUES, canonicalizationAlgorithm)) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
 
-	public void setCanonicalizationAlgorithm(String canonicalizationAlgorithm) throws Exception {
-		if (!canonicalizationAlgorithmValues.equals(canonicalizationAlgorithm)) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+        if (canonicalizationAlgorithm.equals("exclusive")) {
+            this.canonicalizationAlgorithm = CanonicalizationMethod.EXCLUSIVE;
+        } else if (canonicalizationAlgorithm.equals("exclusive-with-comments")) {
+            this.canonicalizationAlgorithm = CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS;
+        } else if (canonicalizationAlgorithm.equals("inclusive")) {
+            this.canonicalizationAlgorithm = CanonicalizationMethod.INCLUSIVE;
+        }
 
-		if (canonicalizationAlgorithm.equals("exclusive")) {
-			canonicalizationAlgorithm = CanonicalizationMethod.EXCLUSIVE;
-		} else if (canonicalizationAlgorithm.equals("exclusive-with-comments")) {
-			canonicalizationAlgorithm = CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS;
-		} else if (canonicalizationAlgorithm.equals("inclusive")) {
-			canonicalizationAlgorithm = CanonicalizationMethod.INCLUSIVE;
-		}
+        this.canonicalizationAlgorithm = canonicalizationAlgorithm;
+    }
 
-		this.canonicalizationAlgorithm = canonicalizationAlgorithm;
-	}
+    public String getDigestAlgorithm() {
+        return digestAlgorithm;
+    }
 
-	public String getDigestAlgorithm() {
-		return digestAlgorithm;
-	}
+    public void setDigestAlgorithm(final String digestAlgorithm) throws Exception {
+        if (!contains(DIGEST_ALGORITHM_VALUES, digestAlgorithm)) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
 
-	public void setDigestAlgorithm(String digestAlgorithm) throws Exception {
-		if (!digestAlgorithmValues.equals(digestAlgorithm)) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+        if (digestAlgorithm.equals("SHA256")) {
+            this.digestAlgorithm = DigestMethod.SHA256;
+        } else if (digestAlgorithm.equals("SHA512")) {
+            this.digestAlgorithm = DigestMethod.SHA512;
+        } else {
+            this.digestAlgorithm = digestAlgorithm;
+        }
+    }
 
-		if (digestAlgorithm.equals("SHA256")) {
-			digestAlgorithm = DigestMethod.SHA256;
-		} else if (digestAlgorithm.equals("SHA512")) {
-			digestAlgorithm = DigestMethod.SHA512;
-		}
+    public String getSignatureAlgorithm() {
+        return signatureAlgorithm;
+    }
 
-		this.digestAlgorithm = digestAlgorithm;
-	}
+    public void setSignatureAlgorithm(final String signatureAlgorithm) throws Exception {
+        if (!contains(SIGNATURE_ALGORITHM_VALUES, signatureAlgorithm)) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
 
-	public String getSignatureAlgorithm() {
-		return signatureAlgorithm;
-	}
+        if (signatureAlgorithm.equals("DSA_SHA1")) {
+            this.signatureAlgorithm = SignatureMethod.DSA_SHA1;
+        } else {
+            this.signatureAlgorithm = signatureAlgorithm;
+        }
+    }
 
-	public void setSignatureAlgorithm(String signatureAlgorithm) throws Exception {
-		if (!signatureAlgorithmValues.equals(signatureAlgorithm)) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+    public String getSignatureNamespacePrefix() {
+        return signatureNamespacePrefix;
+    }
 
-		if (signatureAlgorithm.equals("DSA_SHA1")) {
-			signatureAlgorithm = SignatureMethod.DSA_SHA1;
-		}
+    public void setSignatureNamespacePrefix(final String signatureNamespacePrefix) {
+        this.signatureNamespacePrefix = signatureNamespacePrefix;
+    }
 
-		this.signatureAlgorithm = signatureAlgorithm;
-	}
+    public String getSignatureType() {
+        System.out.println("signatureType = " + Transform.ENVELOPED);
+        return signatureType;
+    }
 
-	public String getSignatureNamespacePrefix() {
-		return signatureNamespacePrefix;
-	}
+    public void setSignatureType(final String signatureType) throws Exception {
+        for (String e : SIGNATURE_TYPE_VALUES) {
+            System.out.println("SIGNATURE_TYPE_VALUES = " + e);
+        }
 
-	public void setSignatureNamespacePrefix(String signatureNamespacePrefix) {
-		this.signatureNamespacePrefix = signatureNamespacePrefix;
-	}
 
-	public String getSignatureType() {
-		System.out.println("signatureType = " + Transform.ENVELOPED);
-		return signatureType;
-	}
+        if (!SIGNATURE_TYPE_VALUES.equals(signatureType)) {
+            //throw new Exception(ErrorMessages.error_signatureType);
+        }
 
-	public void setSignatureType(String signatureType) throws Exception {
-		for (String e : signatureTypeValues) {
-			System.out.println("signatureTypeValues = " + e);	
-		}
-			
-		
-		if (!signatureTypeValues.equals(signatureType)) {
-			//throw new Exception(ErrorMessages.error_signatureType);
-		}
+        this.signatureType = signatureType;
+    }
 
-		this.signatureType = signatureType;
-	}
+    private boolean contains(final String[] strs, final String str) {
+        for (final String s : strs) {
+            if (s.equals(str)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificate.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificate.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificate.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificate.java
@@ -2,7 +2,7 @@ package ro.kuberam.libs.java.crypto.certificates;
 
 
 public class GenerateCertificate {
-	
+
 //	  public static void main(String[] args) throws Exception {
 //		    String keystoreFile = "keyStoreFile.bin";
 //		    String caAlias = "caAlias";
@@ -62,7 +62,7 @@ public class GenerateCertificate {
 //		    output.close();
 //
 //		  }
-	
+
 //    public static X509Certificate generateV1Certificate(KeyPair pair)
 //            throws InvalidKeyException, NoSuchProviderException, SignatureException, CertificateEncodingException, IllegalStateException, NoSuchAlgorithmException
 //        {
@@ -122,7 +122,7 @@ public class GenerateCertificate {
 //        System.out.println(pair.getPrivate());
 //            
 //        }
-	
+
 	/* Creating a Self-Signed Version 3 Certificate
 	import java.math.BigInteger;
 	import java.security.InvalidKeyException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificationPath.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificationPath.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 import java.security.cert.CertPath;

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificationPath.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/GenerateCertificationPath.java
@@ -6,16 +6,16 @@ import java.security.cert.CertificateFactory;
 import java.util.Arrays;
 
 public class GenerateCertificationPath {
-	
-	public static CertPath createCertPath(java.security.cert.Certificate[] certs) {
-	    try {
-	        CertificateFactory certFact = CertificateFactory.getInstance("X.509");
-	        CertPath path = certFact.generateCertPath(Arrays.asList(certs));
-	        return path;
-	    } catch (java.security.cert.CertificateEncodingException e) {
-	    } catch (CertificateException e) {
-	    }
-	    return null;
-	}
+
+    public static CertPath createCertPath(final java.security.cert.Certificate[] certs) {
+        try {
+            final CertificateFactory certFact = CertificateFactory.getInstance("X.509");
+            final CertPath path = certFact.generateCertPath(Arrays.asList(certs));
+            return path;
+        } catch (final java.security.cert.CertificateEncodingException e) {
+        } catch (final CertificateException e) {
+        }
+        return null;
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ParseCertificate.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ParseCertificate.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 public class ParseCertificate {

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificate.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificate.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 import java.security.PublicKey;

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificate.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificate.java
@@ -5,18 +5,18 @@ import java.security.cert.X509Certificate;
 
 public class ValidateCertificate {
 
-	private static final String CERT_DIR = "/data/certs/";
+    private static final String CERT_DIR = "/data/certs/";
 
-	public static void main(String[] args) throws Exception {
-		ValidateCertificate verifyCertificate = new ValidateCertificate();
-		verifyCertificate.runSample();
-	}
+    public static void main(final String[] args) throws Exception {
+        final ValidateCertificate verifyCertificate = new ValidateCertificate();
+        verifyCertificate.runSample();
+    }
 
-	public void runSample() throws Exception {
+    public void runSample() throws Exception {
 
 
 		/*
-		 * Load and verify each certificate. 1. Load certificates into
+         * Load and verify each certificate. 1. Load certificates into
 		 * X509Certificate object 2. Verify each certificate using its
 		 * corresponding public key of the issuer certificate.
 		 */
@@ -30,28 +30,28 @@ public class ValidateCertificate {
 //		verifySignature(rootCA, rootCA);
 //		verifySignature(rootCA, issuerCA);
 //		verifySignature(issuerCA, cert);
-	}
+    }
 
-	/*
-	 * Verify certificate's signature.
-	 * 
-	 * @param issuer The X509 issuer certificate.
-	 * 
-	 * @param cert The X509 certificate to be verified.
-	 * 
-	 * @throws Exception On failure.
-	 */
-	private void verifySignature(X509Certificate issuer, X509Certificate cert)
-			throws Exception {
+    /*
+     * Verify certificate's signature.
+     *
+     * @param issuer The X509 issuer certificate.
+     *
+     * @param cert The X509 certificate to be verified.
+     *
+     * @throws Exception On failure.
+     */
+    private void verifySignature(final X509Certificate issuer, final X509Certificate cert)
+            throws Exception {
 
-		PublicKey verifyingKey = issuer.getPublicKey();
+        final PublicKey verifyingKey = issuer.getPublicKey();
 
 		/*
 		 * Verify the signature on the certificate using the public key. This
 		 * method returns void on successful validation and in case of of a
 		 * failure in verification, it throws a Signature Exception.
 		 */
-		cert.verify(verifyingKey);
-	}
+        cert.verify(verifyingKey);
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationPath.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationPath.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 import java.io.InputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationPath.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationPath.java
@@ -1,7 +1,9 @@
 package ro.kuberam.libs.java.crypto.certificates;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -16,45 +18,42 @@ import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 
 public class ValidateCertificationPath {
-	
-	public static byte[] validate(CertPath certPath) throws Exception {
-	
-	try {
-		//TODO: pay attention that this class maybe uses deprecated java.security.*
-		
-	    // Load the JDK's cacerts keystore file
-	    String filename = System.getProperty("java.home")
-	        + "/lib/security/cacerts".replace('/', File.separatorChar);
-	    FileInputStream is = new FileInputStream(filename);
-	    KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-	    String password = "changeit";
-	    keystore.load(is, password.toCharArray());
 
-	    // Create the parameters for the validator
-	    PKIXParameters params = new PKIXParameters(keystore);
+    public static byte[] validate(final CertPath certPath) throws Exception {
 
-	    // Disable CRL checking since we are not supplying any CRLs
-	    params.setRevocationEnabled(false);
+        try {
+            //TODO: pay attention that this class maybe uses deprecated java.security.*
 
-	    // Create the validator and validate the path
-	    // To create a path, see Creating a Certification Path
-	    CertPathValidator certPathValidator
-	        = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
-	    CertPathValidatorResult result = certPathValidator.validate(certPath, params);
+            final KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            final String password = "changeit";
 
-	    // Get the CA used to validate this path
-	    PKIXCertPathValidatorResult pkixResult = (PKIXCertPathValidatorResult)result;
-	    TrustAnchor ta = pkixResult.getTrustAnchor();
-	    java.security.cert.X509Certificate cert = ta.getTrustedCert();
-	} catch (CertificateException e) {
-	} catch (KeyStoreException e) {
-	} catch (NoSuchAlgorithmException e) {
-	} catch (InvalidAlgorithmParameterException e) {
-	} catch (CertPathValidatorException e) {
-	    // Validation failed
-	}
-	return null;
-	
-}
+            // Load the JDK's cacerts keystore file
+            final Path filename = Paths.get(System.getProperty("java.home"), "lib", "security", "cacerts");
+
+            try (final InputStream is = Files.newInputStream(filename)) {
+                keystore.load(is, password.toCharArray());
+            }
+
+            // Create the parameters for the validator
+            final PKIXParameters params = new PKIXParameters(keystore);
+
+            // Disable CRL checking since we are not supplying any CRLs
+            params.setRevocationEnabled(false);
+
+            // Create the validator and validate the path
+            // To create a path, see Creating a Certification Path
+            final CertPathValidator certPathValidator
+                    = CertPathValidator.getInstance(CertPathValidator.getDefaultType());
+            final CertPathValidatorResult result = certPathValidator.validate(certPath, params);
+
+            // Get the CA used to validate this path
+            final PKIXCertPathValidatorResult pkixResult = (PKIXCertPathValidatorResult) result;
+            final TrustAnchor ta = pkixResult.getTrustAnchor();
+            java.security.cert.X509Certificate cert = ta.getTrustedCert();
+        } catch (final CertificateException | KeyStoreException | NoSuchAlgorithmException | CertPathValidatorException | InvalidAlgorithmParameterException e) {
+        }
+        return null;
+
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationRequest.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/certificates/ValidateCertificationRequest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.certificates;
 
 public class ValidateCertificationRequest {

--- a/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
@@ -20,12 +20,6 @@
 
 package ro.kuberam.libs.java.crypto.digest;
 
-/**
- * Implements the crypto:hash() function.
- * 
- * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
- */
-
 import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -33,104 +27,114 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import ro.kuberam.libs.java.crypto.ErrorMessages;
-import java.util.Base64;
 
+import javax.annotation.Nullable;
+import java.util.Base64;
+import java.util.Optional;
+
+/**
+ * Implements the crypto:hash() function.
+ *
+ * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
+ */
 public class Hash {
 
-	private final static Logger log = Logger.getLogger(Hash.class);
+    private static final Logger LOG = LogManager.getLogger(Hash.class);
 
-	public static String hashString(String data, String algorithm) throws Exception {
-		return hashString(data, algorithm, "");
-	}
+    public static String hashString(final String data, final String algorithm) throws Exception {
+        return hashString(data, algorithm, null);
+    }
 
-	public static String hashString(String data, String algorithm, String format) throws Exception {
+    public static String hashString(final String data, final String algorithm, final @Nullable String format) throws Exception {
 
-		// TODO: validate the format
-		format = format.equals("") ? "base64" : format;
+        // TODO: validate the format
+        final String actualFormat = Optional.ofNullable(format)
+                .filter(str -> !str.isEmpty())
+                .orElse("base64");    // default to Base64
 
-		MessageDigest messageDigester = getMessageDigester(algorithm);
+        final MessageDigest messageDigester = getMessageDigester(algorithm);
+        messageDigester.update(data.getBytes(StandardCharsets.UTF_8));
 
-		messageDigester.update(data.getBytes(StandardCharsets.UTF_8));
+        byte[] resultBytes = messageDigester.digest();
 
-		byte[] resultBytes = messageDigester.digest();
+        if (actualFormat.equals("base64")) {
+            return Base64.getEncoder().encodeToString(resultBytes);
+        } else {
+            return convertToHex(resultBytes);
+        }
+    }
 
-		if (format.equals("base64")) {
-			return Base64.getEncoder().encodeToString(resultBytes);
-		} else {
-			return convertToHex(resultBytes);
-		}
-	}
+    public static String hashBinary(final InputStream data, final String algorithm) throws Exception {
+        return hashBinary(data, algorithm, null);
+    }
 
-	public static String hashBinary(InputStream data, String algorithm) throws Exception {
-		return hashBinary(data, algorithm, "");
-	}
+    public static String hashBinary(final InputStream data, final String algorithm, @Nullable final String format) throws Exception {
 
-	public static String hashBinary(InputStream data, String algorithm, String format) throws Exception {
+        // TODO: validate the format
+        final String actualFormat = Optional.ofNullable(format)
+                .filter(str -> !str.isEmpty())
+                .orElse("base64");    // default to Base64
 
-		// TODO: validate the format
-		format = format.equals("") ? "base64" : format;
+        final byte[] resultBytes;
+        final MessageDigest messageDigester = getMessageDigester(algorithm);
+        try (final BufferedInputStream bis = new BufferedInputStream(data);
+             final DigestInputStream dis = new DigestInputStream(bis, messageDigester)) {
 
-		String result = "";
+            while (dis.read() != -1)
+                ;
 
-		BufferedInputStream bis = new BufferedInputStream(data);
-		MessageDigest messageDigester = getMessageDigester(algorithm);
-		DigestInputStream dis = new DigestInputStream(bis, messageDigester);
+            resultBytes = messageDigester.digest();
+        }
 
-		while (dis.read() != -1)
-			;
+        final String result;
+        if (actualFormat.equals("base64")) {
+            result = Base64.getEncoder().encodeToString(resultBytes);
+        } else {
+            result = convertToHex(resultBytes);
+        }
 
-		byte[] resultBytes = messageDigester.digest();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("hash value is: '" + result);
+        }
 
-		if (format.equals("base64")) {
-			result = Base64.getEncoder().encodeToString(resultBytes);
-		} else {
-			result = convertToHex(resultBytes);
-		}
+        return result;
 
-		log.info("hash value is: '" + result);
+        // byte[] buffer = new byte[bufferSize];
+        // int sizeRead = -1;
+        // while ((sizeRead = in.read(buffer)) != -1) {
+        // digest.update(buffer, 0, sizeRead);
+        // }
+        // in.close();
+        //
+        // byte[] hash = null;
+        // hash = new byte[digest.getDigestLength()];
+        // hash = digest.digest();
+    }
 
-		return result;
+    private static MessageDigest getMessageDigester(final String algorithm) throws Exception {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
+    }
 
-		// byte[] buffer = new byte[bufferSize];
-		// int sizeRead = -1;
-		// while ((sizeRead = in.read(buffer)) != -1) {
-		// digest.update(buffer, 0, sizeRead);
-		// }
-		// in.close();
-		//
-		// byte[] hash = null;
-		// hash = new byte[digest.getDigestLength()];
-		// hash = digest.digest();
-	}
-
-	private static MessageDigest getMessageDigester(String algorithm) throws Exception {
-		MessageDigest messageDigester = null;
-
-		try {
-			messageDigester = MessageDigest.getInstance(algorithm);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
-
-		return messageDigester;
-	}
-
-	private static String convertToHex(byte[] data) {
-		StringBuffer buf = new StringBuffer();
-		for (int i = 0; i < data.length; i++) {
-			int halfbyte = (data[i] >>> 4) & 0x0F;
-			int two_halfs = 0;
-			do {
-				if ((0 <= halfbyte) && (halfbyte <= 9))
-					buf.append((char) ('0' + halfbyte));
-				else
-					buf.append((char) ('a' + (halfbyte - 10)));
-				halfbyte = data[i] & 0x0F;
-			} while (two_halfs++ < 1);
-		}
-		return buf.toString();
-	}
+    private static String convertToHex(final byte[] data) {
+        final StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < data.length; i++) {
+            int halfbyte = (data[i] >>> 4) & 0x0F;
+            int two_halfs = 0;
+            do {
+                if ((0 <= halfbyte) && (halfbyte <= 9))
+                    buf.append((char) ('0' + halfbyte));
+                else
+                    buf.append((char) ('a' + (halfbyte - 10)));
+                halfbyte = data[i] & 0x0F;
+            } while (two_halfs++ < 1);
+        }
+        return buf.toString();
+    }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
@@ -1,23 +1,22 @@
-/*
- *  Copyright (C) 2011 Claudius Teodorescu
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.BufferedInputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digest/Hash.java
@@ -19,10 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
-import java.io.BufferedInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -57,7 +55,7 @@ public class Hash {
         final MessageDigest messageDigester = getMessageDigester(algorithm);
         messageDigester.update(data.getBytes(StandardCharsets.UTF_8));
 
-        byte[] resultBytes = messageDigester.digest();
+        final byte[] resultBytes = messageDigester.digest();
 
         if (actualFormat.equals("base64")) {
             return Base64.getEncoder().encodeToString(resultBytes);
@@ -79,14 +77,13 @@ public class Hash {
 
         final byte[] resultBytes;
         final MessageDigest messageDigester = getMessageDigester(algorithm);
-        try (final BufferedInputStream bis = new BufferedInputStream(data);
-             final DigestInputStream dis = new DigestInputStream(bis, messageDigester)) {
 
-            while (dis.read() != -1)
-                ;
-
-            resultBytes = messageDigester.digest();
+        final byte[] buf = new byte[16 * 1024]; // 16 KB
+        int read = -1;
+        while((read = data.read(buf)) > -1) {
+            messageDigester.update(buf, 0, read);
         }
+        resultBytes = messageDigester.digest();
 
         final String result;
         if (actualFormat.equals("base64")) {
@@ -100,17 +97,6 @@ public class Hash {
         }
 
         return result;
-
-        // byte[] buffer = new byte[bufferSize];
-        // int sizeRead = -1;
-        // while ((sizeRead = in.read(buffer)) != -1) {
-        // digest.update(buffer, 0, sizeRead);
-        // }
-        // in.close();
-        //
-        // byte[] hash = null;
-        // hash = new byte[digest.getDigestLength()];
-        // hash = digest.digest();
     }
 
     private static MessageDigest getMessageDigester(final String algorithm) throws Exception {

--- a/src/main/java/ro/kuberam/libs/java/crypto/digest/Hmac.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digest/Hmac.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.security.InvalidKeyException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/digest/Hmac.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digest/Hmac.java
@@ -4,61 +4,68 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import javax.xml.bind.DatatypeConverter;
 
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import ro.kuberam.libs.java.crypto.ErrorMessages;
 import ro.kuberam.libs.java.crypto.ExpathCryptoModule;
 
 public class Hmac {
 
-	private final static Logger logger = Logger.getLogger(Hmac.class);
+    private static final Logger LOG = LogManager.getLogger(Hmac.class);
 
-	public static String hmac(byte[] data, byte[] secretKey, String algorithm, String format) throws Exception {
-		String result;
+    public static String hmac(final byte[] data, final byte[] secretKey, final String algorithm, @Nullable final String format) throws Exception {
 
-		// TODO: validate the format
-		format = format.equals("") ? "base64" : format;
+        // TODO: validate the format
+        final String actualFormat = Optional.ofNullable(format)
+                .filter(str -> !str.isEmpty())
+                .orElse("base64");    // default to Base64
 
-		logger.debug("secretKey = " + secretKey);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("secretKey = " + secretKey);
+        }
 
-		byte[] resultBytes = hmac(data, secretKey, algorithm);
+        final byte[] resultBytes = hmac(data, secretKey, algorithm);
 
-		if (format.equals("base64")) {
-			result = Base64.getEncoder().encodeToString(resultBytes);
-		} else {
-			result = DatatypeConverter.printHexBinary(resultBytes).toLowerCase();
-		}
-		logger.debug("result = " + result);
+        final String result;
+        if (actualFormat.equals("base64")) {
+            result = Base64.getEncoder().encodeToString(resultBytes);
+        } else {
+            result = DatatypeConverter.printHexBinary(resultBytes).toLowerCase();
+        }
 
-		return result;
-	}
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("result = " + result);
+        }
 
-	public static byte[] hmac(byte[] data, byte[] secretKey, String algorithm) throws Exception {
-		Mac mac = null;
-		HashMap<String, String> javaStandardAlgorithmNames = ExpathCryptoModule.javaStandardAlgorithmNames;
+        return result;
+    }
 
-		if (javaStandardAlgorithmNames.containsKey(algorithm)) {
-			algorithm = javaStandardAlgorithmNames.get(algorithm);
-		}
+    public static byte[] hmac(final byte[] data, final byte[] secretKey, String algorithm) throws Exception {
+        final Map<String, String> javaStandardAlgorithmNames = ExpathCryptoModule.javaStandardAlgorithmNames;
 
-		SecretKeySpec signingKey = new SecretKeySpec(secretKey, algorithm);
+        if (javaStandardAlgorithmNames.containsKey(algorithm)) {
+            algorithm = javaStandardAlgorithmNames.get(algorithm);
+        }
 
-		try {
-			mac = Mac.getInstance(algorithm);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+        final SecretKeySpec signingKey = new SecretKeySpec(secretKey, algorithm);
 
-		try {
-			mac.init(signingKey);
-		} catch (InvalidKeyException ex) {
-		}
+        try {
+            final Mac mac = Mac.getInstance(algorithm);
+            mac.init(signingKey);
+            return mac.doFinal(data);
 
-		return mac.doFinal(data);
-	}
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        } catch (final InvalidKeyException ex) {
+            throw new Exception(ErrorMessages.error_invalidKey);
+        }
+    }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignature.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignature.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.io.*;

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignatureOnBinary.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignatureOnBinary.java
@@ -9,34 +9,33 @@ import ro.kuberam.libs.java.crypto.keyManagement.GenerateKeyPair;
 
 public class GenerateSignatureOnBinary {
 
-	public static byte[] generateSignatureOnBinary(byte[] data,
-			PrivateKey privateKey, String algorithm) throws Exception {
-		Signature dsa = Signature.getInstance(algorithm);
-		dsa.initSign(privateKey);
-		dsa.update(data);
-		byte[] signature = dsa.sign();
-		return signature;
-	}
+    public static byte[] generateSignatureOnBinary(final byte[] data,
+                                                   final PrivateKey privateKey, final String algorithm) throws Exception {
+        final Signature dsa = Signature.getInstance(algorithm);
+        dsa.initSign(privateKey);
+        dsa.update(data);
+        return dsa.sign();
+    }
 
-	public static boolean verifySig(byte[] data, PublicKey key, byte[] sig)
-			throws Exception {
-		Signature signer = Signature.getInstance("SHA1withDSA");
-		signer.initVerify(key);
-		signer.update(data);
-		return (signer.verify(sig));
+    public static boolean verifySig(final byte[] data, final PublicKey key, final byte[] sig)
+            throws Exception {
+        final Signature signer = Signature.getInstance("SHA1withDSA");
+        signer.initVerify(key);
+        signer.update(data);
+        return signer.verify(sig);
 
-	}
+    }
 
-	public static void main(String args[]) throws Exception {
+    public static void main(final String args[]) throws Exception {
 
-		KeyPair keyPair = GenerateKeyPair.generate(1008, "SHA1PRNG",
-				"base64");
+        final KeyPair keyPair = GenerateKeyPair.generate(1008, "SHA1PRNG",
+                "base64");
 
-		byte[] data = { 65, 66, 67, 68, 69, 70, 71, 72, 73, 74 };
-		byte[] signature = generateSignatureOnBinary(data,
-				keyPair.getPrivate(), "SHA1withDSA");
+        final byte[] data = {65, 66, 67, 68, 69, 70, 71, 72, 73, 74};
+        final byte[] signature = generateSignatureOnBinary(data,
+                keyPair.getPrivate(), "SHA1withDSA");
 
-		System.out.println("Signature:\n" + new String(signature));
-	}
+        System.out.println("Signature:\n" + new String(signature));
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignatureOnBinary.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateSignatureOnBinary.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.security.KeyPair;

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateXmlSignature.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateXmlSignature.java
@@ -14,10 +14,7 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Vector;
+import java.util.*;
 
 import javax.xml.crypto.XMLStructure;
 import javax.xml.crypto.dom.DOMStructure;
@@ -56,108 +53,105 @@ import ro.kuberam.libs.java.crypto.ErrorMessages;
 
 /**
  * Implements the module definition.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 
 public class GenerateXmlSignature {
 
-	public static String generate(Document inputDoc, String canonicalizationAlgorithm,
-			String digestAlgorithm, String signatureAlgorithm, String signatureNamespacePrefix,
-			String signatureType, final String xpathExprString, String[] certificateDetails,
-			InputStream keyStoreInputStream) throws Exception {
+    public static String generate(final Document inputDoc, final String canonicalizationAlgorithm,
+                                  final String digestAlgorithm, final String signatureAlgorithm, final String signatureNamespacePrefix,
+                                  final String signatureType, final String xpathExprString, final String[] certificateDetails,
+                                  final InputStream keyStoreInputStream) throws Exception {
 
-		String canonicalizationAlgorithmURI = getCanonicalizationAlgorithmUri(canonicalizationAlgorithm);
-		String digestAlgorithmURI = getDigestAlgorithmURI(digestAlgorithm);
-		String signatureAlgorithmURI = getSignatureAlgorithmURI(signatureAlgorithm);
-		String keyPairAlgorithm = signatureAlgorithm.substring(0, 3);
+        final String canonicalizationAlgorithmURI = getCanonicalizationAlgorithmUri(canonicalizationAlgorithm);
+        final String digestAlgorithmURI = getDigestAlgorithmURI(digestAlgorithm);
+        final String signatureAlgorithmURI = getSignatureAlgorithmURI(signatureAlgorithm);
+        final String keyPairAlgorithm = signatureAlgorithm.substring(0, 3);
 
-		// Create a DOM XMLSignatureFactory
-		final XMLSignatureFactory sigFactory = XMLSignatureFactory.getInstance("DOM");
+        // Create a DOM XMLSignatureFactory
+        final XMLSignatureFactory sigFactory = XMLSignatureFactory.getInstance("DOM");
 
-		// Create a Reference to the signed element
-		Node sigParent = null;
-		List transforms = null;
+        // Create a Reference to the signed element
+        Node sigParent = null;
+        final List<Transform> transforms;
 
-		if (xpathExprString == null) {
-			sigParent = inputDoc.getDocumentElement();
-			transforms = Collections.singletonList(sigFactory.newTransform(Transform.ENVELOPED,
-					(TransformParameterSpec) null));
-		} else {
-			XPathFactory factory = XPathFactory.newInstance();
-			XPath xpath = factory.newXPath();
-			// Find the node to be signed by PATH
-			XPathExpression expr = xpath.compile(xpathExprString);
-			NodeList nodes = (NodeList) expr.evaluate(inputDoc, XPathConstants.NODESET);
-			if (nodes.getLength() < 1) {
-				// TODO this error message has to replaced
-				throw new Exception(ErrorMessages.error_unknownAlgorithm);
-			}
+        if (xpathExprString == null) {
+            sigParent = inputDoc.getDocumentElement();
+            transforms = Collections.singletonList(sigFactory.newTransform(Transform.ENVELOPED,
+                    (TransformParameterSpec) null));
+        } else {
+            final XPathFactory factory = XPathFactory.newInstance();
+            final XPath xpath = factory.newXPath();
+            // Find the node to be signed by PATH
+            final XPathExpression expr = xpath.compile(xpathExprString);
+            final NodeList nodes = (NodeList) expr.evaluate(inputDoc, XPathConstants.NODESET);
+            if (nodes.getLength() < 1) {
+                // TODO this error message has to replaced
+                throw new Exception(ErrorMessages.error_unknownAlgorithm);
+            }
 
-			// Node nodeToSign = nodes.item(0);
-			// sigParent = nodeToSign.getParentNode();
-			sigParent = nodes.item(0);
-			/*
+            // Node nodeToSign = nodes.item(0);
+            // sigParent = nodeToSign.getParentNode();
+            sigParent = nodes.item(0);
+            /*
 			 * if ( signatureType.equals( "enveloped" ) ) { sigParent = (
 			 * nodes.item(0) ).getParentNode(); }
 			 */
-			transforms = new ArrayList<Transform>() {
-				{
-					add(sigFactory.newTransform(Transform.XPATH, new XPathFilterParameterSpec(
-							xpathExprString)));
-					add(sigFactory.newTransform(Transform.ENVELOPED, (TransformParameterSpec) null));
-				}
-			};
-		}
+            transforms = Arrays.asList(
+                    sigFactory.newTransform(Transform.XPATH, new XPathFilterParameterSpec(
+                            xpathExprString)),
+                    sigFactory.newTransform(Transform.ENVELOPED, (TransformParameterSpec) null));
+        }
 
-		Reference ref = sigFactory.newReference("", sigFactory.newDigestMethod(digestAlgorithmURI, null),
-				transforms, null, null);
+        final Reference ref = sigFactory.newReference("", sigFactory.newDigestMethod(digestAlgorithmURI, null),
+                transforms, null, null);
 
-		// Create the SignedInfo
-		SignedInfo si = sigFactory.newSignedInfo(sigFactory.newCanonicalizationMethod(
-				canonicalizationAlgorithmURI, (C14NMethodParameterSpec) null), sigFactory
-				.newSignatureMethod(signatureAlgorithmURI, null), Collections.singletonList(ref));
+        // Create the SignedInfo
+        final SignedInfo si = sigFactory.newSignedInfo(sigFactory.newCanonicalizationMethod(
+                canonicalizationAlgorithmURI, (C14NMethodParameterSpec) null), sigFactory
+                .newSignatureMethod(signatureAlgorithmURI, null), Collections.singletonList(ref));
 
-		// generate key pair
-		KeyInfo ki = null;
-		PrivateKey privateKey = null;
-		if (certificateDetails[0].length() != 0) {
-			KeyStore keyStore = null;
-			try {
-				keyStore = KeyStore.getInstance(certificateDetails[0]);
-			} catch (Exception ex) {
-				throw new Exception(ErrorMessages.error_keystoreType);
-			}
-			keyStore.load(keyStoreInputStream, certificateDetails[1].toCharArray());
-			String alias = certificateDetails[2];
-			if (!keyStore.containsAlias(alias)) {
-				throw new Exception(ErrorMessages.error_aliasKey);
-			}
-			privateKey = (PrivateKey) keyStore.getKey(alias, certificateDetails[3].toCharArray());
-			X509Certificate cert = (X509Certificate) keyStore.getCertificate(alias);
-			PublicKey publicKey = cert.getPublicKey();
-			KeyInfoFactory kif = sigFactory.getKeyInfoFactory();
-			Vector<Object> kiContent = new Vector<Object>();
-			KeyValue keyValue = kif.newKeyValue(publicKey);
-			kiContent.add(keyValue);
-			List x509Content = new ArrayList();
-			X509IssuerSerial issuer = kif.newX509IssuerSerial(cert.getIssuerX500Principal().getName(),
-					cert.getSerialNumber());
-			x509Content.add(cert.getSubjectX500Principal().getName());
-			x509Content.add(issuer);
-			x509Content.add(cert);
-			X509Data x509Data = kif.newX509Data(x509Content);
-			kiContent.add(x509Data);
-			ki = kif.newKeyInfo(kiContent);
-		} else {
-			KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyPairAlgorithm);
-			kpg.initialize(512);
-			KeyPair kp = kpg.generateKeyPair();
-			KeyInfoFactory kif = sigFactory.getKeyInfoFactory();
-			KeyValue kv = kif.newKeyValue(kp.getPublic());
-			ki = kif.newKeyInfo(Collections.singletonList(kv));
-			privateKey = kp.getPrivate();
-		}
+        // generate key pair
+        final KeyInfo ki;
+        final PrivateKey privateKey;
+        if (certificateDetails[0].length() != 0) {
+            final KeyStore keyStore;
+            try {
+                keyStore = KeyStore.getInstance(certificateDetails[0]);
+            } catch (final Exception ex) {
+                throw new Exception(ErrorMessages.error_keystoreType);
+            }
+            keyStore.load(keyStoreInputStream, certificateDetails[1].toCharArray());
+            final String alias = certificateDetails[2];
+            if (!keyStore.containsAlias(alias)) {
+                throw new Exception(ErrorMessages.error_aliasKey);
+            }
+            privateKey = (PrivateKey) keyStore.getKey(alias, certificateDetails[3].toCharArray());
+            final X509Certificate cert = (X509Certificate) keyStore.getCertificate(alias);
+            final PublicKey publicKey = cert.getPublicKey();
+            final KeyInfoFactory kif = sigFactory.getKeyInfoFactory();
+            final List<XMLStructure> kiContent = new ArrayList<>();
+            final KeyValue keyValue = kif.newKeyValue(publicKey);
+            kiContent.add(keyValue);
+            final List<Object> x509Content = new ArrayList<>();
+            final X509IssuerSerial issuer = kif.newX509IssuerSerial(cert.getIssuerX500Principal().getName(),
+                    cert.getSerialNumber());
+            x509Content.add(cert.getSubjectX500Principal().getName());
+            x509Content.add(issuer);
+            x509Content.add(cert);
+            final X509Data x509Data = kif.newX509Data(x509Content);
+            kiContent.add(x509Data);
+            ki = kif.newKeyInfo(kiContent);
+        } else {
+            final KeyPairGenerator kpg = KeyPairGenerator.getInstance(keyPairAlgorithm);
+            kpg.initialize(512);
+            final KeyPair kp = kpg.generateKeyPair();
+            final KeyInfoFactory kif = sigFactory.getKeyInfoFactory();
+            final KeyValue kv = kif.newKeyValue(kp.getPublic());
+            ki = kif.newKeyInfo(Collections.singletonList(kv));
+            privateKey = kp.getPrivate();
+        }
 
 		/*
 		 * <element name="X509Data" type="ds:X509DataType"/> <complexType
@@ -170,111 +164,114 @@ public class GenerateXmlSignature {
 		 * processContents="lax"/> </choice> </sequence> </complexType> >
 		 */
 
-		// Create a DOMSignContext and specify the location of the resulting
-		// XMLSignature's parent element
-		DOMSignContext dsc = null;
-		XMLSignature signature = null;
-		Document signatureDoc = null;
-		if (signatureType.equals("enveloped")) {
-			dsc = new DOMSignContext(privateKey, sigParent);
-			signature = sigFactory.newXMLSignature(si, ki);
-		} else if (signatureType.equals("detached")) {
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(true);
-			sigParent = dbf.newDocumentBuilder().newDocument();
-			dsc = new DOMSignContext(privateKey, sigParent);
-			signature = sigFactory.newXMLSignature(si, ki);
-		} else if (signatureType.equals("enveloping")) {
-			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-			dbf.setNamespaceAware(true);
-			signatureDoc = dbf.newDocumentBuilder().newDocument();
-			XMLStructure content = new DOMStructure(sigParent);
-			XMLObject xmlobj = sigFactory.newXMLObject(Collections.singletonList(content), "object", null,
-					null);
-			dsc = new DOMSignContext(privateKey, signatureDoc);
-			signature = sigFactory.newXMLSignature(si, ki, Collections.singletonList(xmlobj), null, null);
-		}
-		dsc.setDefaultNamespacePrefix(signatureNamespacePrefix);
+        // Create a DOMSignContext and specify the location of the resulting
+        // XMLSignature's parent element
+        DOMSignContext dsc = null;
+        XMLSignature signature = null;
+        Document signatureDoc = null;
+        if (signatureType.equals("enveloped")) {
+            dsc = new DOMSignContext(privateKey, sigParent);
+            signature = sigFactory.newXMLSignature(si, ki);
+        } else if (signatureType.equals("detached")) {
+            final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            sigParent = dbf.newDocumentBuilder().newDocument();
+            dsc = new DOMSignContext(privateKey, sigParent);
+            signature = sigFactory.newXMLSignature(si, ki);
+        } else if (signatureType.equals("enveloping")) {
+            final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            signatureDoc = dbf.newDocumentBuilder().newDocument();
+            final XMLStructure content = new DOMStructure(sigParent);
+            final XMLObject xmlobj = sigFactory.newXMLObject(Collections.singletonList(content), "object", null,
+                    null);
+            dsc = new DOMSignContext(privateKey, signatureDoc);
+            signature = sigFactory.newXMLSignature(si, ki, Collections.singletonList(xmlobj), null, null);
+        }
+        dsc.setDefaultNamespacePrefix(signatureNamespacePrefix);
 
-		// Marshal, generate and sign
-		signature.sign(dsc);
+        // Marshal, generate and sign
+        signature.sign(dsc);
 
-		DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
-		DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
-		LSSerializer serializer = impl.createLSSerializer();
-		if (signatureType.equals("enveloping")) {
-			return serializer.writeToString(signatureDoc);
-		} else {
-			return serializer.writeToString(sigParent);
-		}
-	}
+        final DOMImplementationRegistry registry = DOMImplementationRegistry.newInstance();
+        final DOMImplementationLS impl = (DOMImplementationLS) registry.getDOMImplementation("LS");
+        final LSSerializer serializer = impl.createLSSerializer();
+        if (signatureType.equals("enveloping")) {
+            return serializer.writeToString(signatureDoc);
+        } else {
+            return serializer.writeToString(sigParent);
+        }
+    }
 
-	// public static void main(String[] args) throws
-	// ParserConfigurationException,
-	// SAXException, IOException, Exception {
-	// String docString =
-	// "<data><a xml:id=\"type\"><b>23</b><c><d/></c></a></data>";
-	// DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-	// dbf.setNamespaceAware(true);
-	// Document inputDoc = dbf.newDocumentBuilder().parse(
-	// new InputSource(new StringReader(docString)));
-	//
-	// String[] certificateDetails = new String[5];
-	// certificateDetails[0] = "JKS";
-	// certificateDetails[1] = "ab987c";
-	// certificateDetails[2] = "eXist";
-	// certificateDetails[3] = "kpi135";
-	//
-	// String domString = generateXmlSignature(inputDoc,
-	// CanonicalizationMethod.EXCLUSIVE, DigestMethod.SHA1,
-	// SignatureMethod.DSA_SHA1, "DSA", "ds", "enveloped", "//b",
-	// certificateDetails, getClass().getResourceAsStream(
-	// "../tests/resources/mykeystoreEXist.ks"));
-	// System.out.print(domString + "\n");
-	// }
+    // public static void main(String[] args) throws
+    // ParserConfigurationException,
+    // SAXException, IOException, Exception {
+    // String docString =
+    // "<data><a xml:id=\"type\"><b>23</b><c><d/></c></a></data>";
+    // DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    // dbf.setNamespaceAware(true);
+    // Document inputDoc = dbf.newDocumentBuilder().parse(
+    // new InputSource(new StringReader(docString)));
+    //
+    // String[] certificateDetails = new String[5];
+    // certificateDetails[0] = "JKS";
+    // certificateDetails[1] = "ab987c";
+    // certificateDetails[2] = "eXist";
+    // certificateDetails[3] = "kpi135";
+    //
+    // String domString = generateXmlSignature(inputDoc,
+    // CanonicalizationMethod.EXCLUSIVE, DigestMethod.SHA1,
+    // SignatureMethod.DSA_SHA1, "DSA", "ds", "enveloped", "//b",
+    // certificateDetails, getClass().getResourceAsStream(
+    // "../tests/resources/mykeystoreEXist.ks"));
+    // System.out.print(domString + "\n");
+    // }
 
-	private static String getCanonicalizationAlgorithmUri(String canonicalizationAlgorithm)
-			throws Exception {
-		String canonicalizationAlgorithmURI = CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS;
-		if (canonicalizationAlgorithm.equals("exclusive")) {
-			canonicalizationAlgorithmURI = CanonicalizationMethod.EXCLUSIVE;
-		} else if (canonicalizationAlgorithm.equals("exclusive-with-comments")) {
-			canonicalizationAlgorithmURI = CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS;
-		} else if (canonicalizationAlgorithm.equals("inclusive")) {
-			canonicalizationAlgorithmURI = CanonicalizationMethod.INCLUSIVE;
-		} else {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
-		return canonicalizationAlgorithmURI;
+    private static String getCanonicalizationAlgorithmUri(final String canonicalizationAlgorithm)
+            throws Exception {
+        switch (canonicalizationAlgorithm) {
+            case "exclusive":
+                return CanonicalizationMethod.EXCLUSIVE;
 
-	}
+            case "exclusive-with-comments":
+                return CanonicalizationMethod.EXCLUSIVE_WITH_COMMENTS;
 
-	private static String getDigestAlgorithmURI(String digestAlgorithm) throws Exception {
-		String digestAlgorithmURI = "";
-		if (digestAlgorithm.equals("SHA256")) {
-			digestAlgorithmURI = DigestMethod.SHA256;
-		} else if (digestAlgorithm.equals("SHA512")) {
-			digestAlgorithmURI = DigestMethod.SHA512;
-		} else if (digestAlgorithm.equals("SHA1") || digestAlgorithm.equals("")) {
-			digestAlgorithmURI = DigestMethod.SHA1;
-		} else {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+            case "inclusive":
+                return CanonicalizationMethod.INCLUSIVE;
 
-		return digestAlgorithmURI;
-	}
+            default:
+                throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
+    }
 
-	private static String getSignatureAlgorithmURI(String signatureAlgorithm) throws Exception {
-		String signatureAlgorithmURI = "";
-		if (signatureAlgorithm.equals("DSA_SHA1")) {
-			signatureAlgorithmURI = SignatureMethod.DSA_SHA1;
-		} else if (signatureAlgorithm.equals("RSA_SHA1") || signatureAlgorithm.equals("")) {
-			signatureAlgorithmURI = SignatureMethod.RSA_SHA1;
-		} else {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		}
+    private static String getDigestAlgorithmURI(final String digestAlgorithm) throws Exception {
+        switch (digestAlgorithm) {
+            case "SHA256":
+                return DigestMethod.SHA256;
 
-		return signatureAlgorithmURI;
+            case "SHA512":
+                return DigestMethod.SHA512;
 
-	}
+            case "SHA1":
+            case "":
+                return DigestMethod.SHA1;
+
+            default:
+                throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
+    }
+
+    private static String getSignatureAlgorithmURI(final String signatureAlgorithm) throws Exception {
+        switch (signatureAlgorithm) {
+            case "DSA_SHA1":
+                return SignatureMethod.DSA_SHA1;
+
+            case "RSA_SHA1":
+            case "":
+                return SignatureMethod.RSA_SHA1;
+
+            default:
+                throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        }
+    }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateXmlSignature.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateXmlSignature.java
@@ -1,9 +1,21 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateSignatureOnBinary.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateSignatureOnBinary.java
@@ -9,34 +9,32 @@ import ro.kuberam.libs.java.crypto.keyManagement.GenerateKeyPair;
 
 public class ValidateSignatureOnBinary {
 
-	public static byte[] generateSignatureOnBinary(byte[] data,
-			PrivateKey privateKey, String algorithm) throws Exception {
-		Signature dsa = Signature.getInstance(algorithm);
-		dsa.initSign(privateKey);
-		dsa.update(data);
-		byte[] signature = dsa.sign();
-		return signature;
-	}
+    public static byte[] generateSignatureOnBinary(final byte[] data,
+                                                   final PrivateKey privateKey, final String algorithm) throws Exception {
+        final Signature dsa = Signature.getInstance(algorithm);
+        dsa.initSign(privateKey);
+        dsa.update(data);
+        return dsa.sign();
+    }
 
-	public static boolean validateSignatureOnBinary(byte[] data, PublicKey publicKey, byte[] signature, String algorithm)
-			throws Exception {
-		Signature signer = Signature.getInstance(algorithm);
-		signer.initVerify(publicKey);
-		signer.update(data);
-		return (signer.verify(signature));
+    public static boolean validateSignatureOnBinary(final byte[] data, final PublicKey publicKey, final byte[] signature, final String algorithm)
+            throws Exception {
+        final Signature signer = Signature.getInstance(algorithm);
+        signer.initVerify(publicKey);
+        signer.update(data);
+        return signer.verify(signature);
 
-	}
+    }
 
-	public static void main(String args[]) throws Exception {
+    public static void main(final String args[]) throws Exception {
+        final KeyPair keyPair = GenerateKeyPair.generate(1008, "SHA1PRNG",
+                "base64");
 
-		KeyPair keyPair = GenerateKeyPair.generate(1008, "SHA1PRNG",
-				"base64");
+        final byte[] data = {65, 66, 67, 68, 69, 70, 71, 72, 73, 74};
+        final boolean validate = validateSignatureOnBinary(data,
+                keyPair.getPublic(), null, "SHA1withDSA");
 
-		byte[] data = { 65, 66, 67, 68, 69, 70, 71, 72, 73, 74 };
-		boolean validate = validateSignatureOnBinary(data,
-				keyPair.getPublic(), null, "SHA1withDSA");
-
-		System.out.println("Validate:\n" + validate);
-	}
+        System.out.println("Validate:\n" + validate);
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateSignatureOnBinary.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateSignatureOnBinary.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.security.KeyPair;

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateXmlSignature.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateXmlSignature.java
@@ -31,119 +31,124 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
 /**
  * Cryptographic extension functions.
- * 
+ *
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 
 public class ValidateXmlSignature {
 
-	private final static Logger logger = Logger.getLogger(ValidateXmlSignature.class);
+    private static final Logger LOG = LogManager.getLogger(ValidateXmlSignature.class);
 
-	public static Boolean validate(Document inputDoc) throws Exception {
+    public static Boolean validate(Document inputDoc) throws Exception {
 
-		// Find Signature element
-		logger.info("Claudius test: " + inputDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature").getLength());
-		//NodeList nl = inputDoc.getElementsByTagName("Signature");
-		//NodeList nl = inputDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
-		
-		XPathFactory factory = XPathFactory.newInstance();
-		XPath xpath = factory.newXPath();
-		// Find the node to be signed by PATH
-		XPathExpression expr = xpath.compile("//*[local-name() = 'Signature' and namespace-uri() = '" + XMLSignature.XMLNS + "']");
-		Node nl = (Node) expr.evaluate(inputDoc, XPathConstants.NODE);
-		
+        // Find Signature element
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Claudius test: " + inputDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature").getLength());
+        }
+        //NodeList nl = inputDoc.getElementsByTagName("Signature");
+        //NodeList nl = inputDoc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
+
+        XPathFactory factory = XPathFactory.newInstance();
+        XPath xpath = factory.newXPath();
+        // Find the node to be signed by PATH
+        XPathExpression expr = xpath.compile("//*[local-name() = 'Signature' and namespace-uri() = '" + XMLSignature.XMLNS + "']");
+        Node nl = (Node) expr.evaluate(inputDoc, XPathConstants.NODE);
+
 //		if (nl.getLength() == 0) {
 //			throw new XPathException(ErrorMessages.err_CX15);
 //		}
 
-		// Create a DOM XMLSignatureFactory that will be used to unmarshal the
-		// document containing the XMLSignature
-		XMLSignatureFactory fac = XMLSignatureFactory.getInstance("DOM");
-		logger.info("Claudius test: " + nl.getNodeName());
-		// Create a DOMValidateContext and specify a KeyValue KeySelector
-		// and document context
-		DOMValidateContext valContext = new DOMValidateContext(new KeyValueKeySelector(), nl);
-		
-		// unmarshal the XMLSignature
-		XMLSignature signature = fac.unmarshalXMLSignature(valContext);
+        // Create a DOM XMLSignatureFactory that will be used to unmarshal the
+        // document containing the XMLSignature
+        XMLSignatureFactory fac = XMLSignatureFactory.getInstance("DOM");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Claudius test: " + nl.getNodeName());
+        }
+        // Create a DOMValidateContext and specify a KeyValue KeySelector
+        // and document context
+        DOMValidateContext valContext = new DOMValidateContext(new KeyValueKeySelector(), nl);
 
-		// Validate the XMLSignature (generated above)
-		boolean coreValidity = signature.validate(valContext);
+        // unmarshal the XMLSignature
+        XMLSignature signature = fac.unmarshalXMLSignature(valContext);
 
-		// Check core validation status
-		if (coreValidity == false) {
-			System.err.println("Signature failed core validation");
-			boolean sv = signature.getSignatureValue().validate(valContext);
-			System.out.println("signature validation status: " + sv);
-			// check the validation status of each Reference
-			Iterator iterator = signature.getSignedInfo().getReferences().iterator();
-			for (int j = 0; iterator.hasNext(); j++) {
-				boolean refValid = ((Reference) iterator.next()).validate(valContext);
-				System.out.println("ref[" + j + "] validity status: " + refValid);
-			}
-		}
+        // Validate the XMLSignature (generated above)
+        boolean coreValidity = signature.validate(valContext);
 
-		return coreValidity;
-	}
+        // Check core validation status
+        if (coreValidity == false) {
+            System.err.println("Signature failed core validation");
+            boolean sv = signature.getSignatureValue().validate(valContext);
+            System.out.println("signature validation status: " + sv);
+            // check the validation status of each Reference
+            Iterator iterator = signature.getSignedInfo().getReferences().iterator();
+            for (int j = 0; iterator.hasNext(); j++) {
+                boolean refValid = ((Reference) iterator.next()).validate(valContext);
+                System.out.println("ref[" + j + "] validity status: " + refValid);
+            }
+        }
 
-	/**
-	 * KeySelector which retrieves the public key out of the KeyValue element
-	 * and returns it. NOTE: If the key algorithm doesn't match signature
-	 * algorithm, then the public key will be ignored.
-	 */
-	private static class KeyValueKeySelector extends KeySelector {
-		public KeySelectorResult select(KeyInfo keyInfo, KeySelector.Purpose purpose, AlgorithmMethod method, XMLCryptoContext context)
-				throws KeySelectorException {
-			if (keyInfo == null) {
-				throw new KeySelectorException("Null KeyInfo object!");
-			}
-			SignatureMethod sm = (SignatureMethod) method;
-			List list = keyInfo.getContent();
+        return coreValidity;
+    }
 
-			for (int i = 0; i < list.size(); i++) {
-				XMLStructure xmlStructure = (XMLStructure) list.get(i);
-				if (xmlStructure instanceof KeyValue) {
-					PublicKey pk = null;
-					try {
-						pk = ((KeyValue) xmlStructure).getPublicKey();
-					} catch (KeyException ke) {
-						throw new KeySelectorException(ke);
-					}
-					// make sure algorithm is compatible with method
-					if (algEquals(sm.getAlgorithm(), pk.getAlgorithm())) {
-						return new SimpleKeySelectorResult(pk);
-					}
-				}
-			}
-			throw new KeySelectorException("No KeyValue element found!");
-		}
+    /**
+     * KeySelector which retrieves the public key out of the KeyValue element
+     * and returns it. NOTE: If the key algorithm doesn't match signature
+     * algorithm, then the public key will be ignored.
+     */
+    private static class KeyValueKeySelector extends KeySelector {
+        public KeySelectorResult select(KeyInfo keyInfo, KeySelector.Purpose purpose, AlgorithmMethod method, XMLCryptoContext context)
+                throws KeySelectorException {
+            if (keyInfo == null) {
+                throw new KeySelectorException("Null KeyInfo object!");
+            }
+            SignatureMethod sm = (SignatureMethod) method;
+            List list = keyInfo.getContent();
 
-		static boolean algEquals(String algURI, String algName) {
-			if (algName.equalsIgnoreCase("DSA") && algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
-				return true;
-			} else if (algName.equalsIgnoreCase("RSA") && algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
-				return true;
-			} else {
-				return false;
-			}
-		}
-	}
+            for (int i = 0; i < list.size(); i++) {
+                XMLStructure xmlStructure = (XMLStructure) list.get(i);
+                if (xmlStructure instanceof KeyValue) {
+                    PublicKey pk = null;
+                    try {
+                        pk = ((KeyValue) xmlStructure).getPublicKey();
+                    } catch (KeyException ke) {
+                        throw new KeySelectorException(ke);
+                    }
+                    // make sure algorithm is compatible with method
+                    if (algEquals(sm.getAlgorithm(), pk.getAlgorithm())) {
+                        return new SimpleKeySelectorResult(pk);
+                    }
+                }
+            }
+            throw new KeySelectorException("No KeyValue element found!");
+        }
 
-	private static class SimpleKeySelectorResult implements KeySelectorResult {
-		private PublicKey pk;
+        static boolean algEquals(String algURI, String algName) {
+            if (algName.equalsIgnoreCase("DSA") && algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
+                return true;
+            } else if (algName.equalsIgnoreCase("RSA") && algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
 
-		SimpleKeySelectorResult(PublicKey pk) {
-			this.pk = pk;
-		}
+    private static class SimpleKeySelectorResult implements KeySelectorResult {
+        private PublicKey pk;
 
-		public Key getKey() {
-			return pk;
-		}
-	}
+        SimpleKeySelectorResult(PublicKey pk) {
+            this.pk = pk;
+        }
+
+        public Key getKey() {
+            return pk;
+        }
+    }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateXmlSignature.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateXmlSignature.java
@@ -1,9 +1,21 @@
-/*
- *  eXist Java Cryptographic Extension
- *  Copyright (C) 2010 Claudius Teodorescu at http://kuberam.ro
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  Released under LGPL License - http://gnu.org/licenses/lgpl.html.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/encrypt/AsymmetricEncryption.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/encrypt/AsymmetricEncryption.java
@@ -21,14 +21,16 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.charset.StandardCharsets;
+import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
+import javax.annotation.Nullable;
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
@@ -37,115 +39,115 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
+
 import java.util.Base64;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
- * 
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 public class AsymmetricEncryption {
 
-	public static String encryptString(String input, String publicKey, String transformationName) throws Exception {
+    public static String encryptString(final String input, final String publicKey, final String transformationName) throws Exception {
+        final String algorithm = (transformationName.contains("/"))
+                ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
 
-		Cipher cipher = null;
-		String algorithm = (transformationName.contains("/"))
-				? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
+        final Cipher cipher;
+        try {
+            cipher = Cipher.getInstance(transformationName);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        } catch (final NoSuchPaddingException ex) {
+            throw new Exception(ErrorMessages.error_noPadding);
+        }
 
-		try {
-			cipher = Cipher.getInstance(transformationName);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		} catch (NoSuchPaddingException ex) {
-			throw new Exception(ErrorMessages.error_noPadding);
-		}
+        final X509EncodedKeySpec publicKeySpecification = new X509EncodedKeySpec(Base64.getDecoder().decode(publicKey));
+        final PublicKey publicKey1 = KeyFactory.getInstance(algorithm).generatePublic(publicKeySpecification);
 
-		X509EncodedKeySpec publicKeySpecification = new X509EncodedKeySpec(Base64.getDecoder().decode(publicKey));
-		PublicKey publicKey1 = KeyFactory.getInstance(algorithm).generatePublic(publicKeySpecification);
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, publicKey1);
+        } catch (final InvalidKeyException ex) {
+            throw new Exception(ErrorMessages.error_cryptoKey);
+        }
 
-		try {
-			cipher.init(Cipher.ENCRYPT_MODE, publicKey1);
-		} catch (InvalidKeyException ex) {
-			throw new Exception(ErrorMessages.error_cryptoKey);
-		}
+        final byte[] resultBytes;
+        try {
+            resultBytes = cipher.doFinal(input.getBytes());
+        } catch (final IllegalBlockSizeException ex) {
+            throw new Exception(ErrorMessages.error_blockSize);
+        } catch (final BadPaddingException ex) {
+            throw new Exception(ErrorMessages.error_incorrectPadding);
+        }
 
-		byte[] resultBytes = null;
-		try {
-			resultBytes = cipher.doFinal(input.getBytes());
-		} catch (IllegalBlockSizeException ex) {
-			throw new Exception(ErrorMessages.error_blockSize);
-		} catch (BadPaddingException ex) {
-			throw new Exception(ErrorMessages.error_incorrectPadding);
-		}
+        return getString(resultBytes);
+    }
 
-		return getString(resultBytes);
-	}
+    public static String decryptString(final String encryptedInput, final String plainKey, final String transformationName, final String iv,
+                                       @Nullable final String provider) throws Exception {
+        final String algorithm = (transformationName.contains("/"))
+                ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
 
-	public static String decryptString(String encryptedInput, String plainKey, String transformationName, String iv,
-			String provider) throws Exception {
+        final String actualProvider = Optional.ofNullable(provider)
+                .filter(str -> !str.isEmpty())
+                .orElse("SunJCE");    // default to SunJCE
 
-		IvParameterSpec ivSpec = null;
-		String algorithm = (transformationName.contains("/"))
-				? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
-		provider = provider.equals("") ? "SunJCE" : provider;
-		Cipher cipher = null;
+        final Cipher cipher;
+        try {
+            cipher = Cipher.getInstance(transformationName, actualProvider);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        } catch (final NoSuchPaddingException ex) {
+            throw new Exception(ErrorMessages.error_noPadding);
+        }
 
-		try {
-			cipher = Cipher.getInstance(transformationName, provider);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		} catch (NoSuchPaddingException ex) {
-			throw new Exception(ErrorMessages.error_noPadding);
-		}
+        final SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(UTF_8), algorithm);
+        if (transformationName.contains("/")) {
+            final IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes(UTF_8), 0, 16);
+            try {
+                cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
+            } catch (final InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        } else {
+            try {
+                cipher.init(Cipher.DECRYPT_MODE, skeySpec);
+            } catch (final InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        }
 
-		SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(StandardCharsets.UTF_8), algorithm);
+        try {
+            final byte[] resultBytes = cipher.doFinal(getBytes(encryptedInput));
+            return new String(resultBytes, UTF_8);
+        } catch (final IllegalBlockSizeException ex) {
+            throw new Exception(ErrorMessages.error_blockSize);
+        } catch (final BadPaddingException ex) {
+            throw new Exception(ErrorMessages.error_incorrectPadding);
+        }
+    }
 
-		if (transformationName.contains("/")) {
-			ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8), 0, 16);
-			try {
-				cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		} else {
-			try {
-				cipher.init(Cipher.DECRYPT_MODE, skeySpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		}
+    public static String getString(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            final byte b = bytes[i];
+            sb.append((int) (0x00FF & b));
+            if (i + 1 < bytes.length) {
+                sb.append("-");
+            }
+        }
+        return sb.toString();
+    }
 
-		byte[] resultBytes = null;
-		try {
-			resultBytes = cipher.doFinal(getBytes(encryptedInput));
-		} catch (IllegalBlockSizeException ex) {
-			throw new Exception(ErrorMessages.error_blockSize);
-		} catch (BadPaddingException ex) {
-			throw new Exception(ErrorMessages.error_incorrectPadding);
-		}
-
-		return new String(resultBytes);
-	}
-
-	public static String getString(byte[] bytes) {
-		StringBuffer sb = new StringBuffer();
-		for (int i = 0; i < bytes.length; i++) {
-			byte b = bytes[i];
-			sb.append((int) (0x00FF & b));
-			if (i + 1 < bytes.length) {
-				sb.append("-");
-			}
-		}
-		return sb.toString();
-	}
-
-	public static byte[] getBytes(String str) {
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		StringTokenizer st = new StringTokenizer(str, "-", false);
-		while (st.hasMoreTokens()) {
-			int i = Integer.parseInt(st.nextToken());
-			bos.write((byte) i);
-		}
-		return bos.toByteArray();
-	}
+    public static byte[] getBytes(final String str) throws IOException {
+        final StringTokenizer st = new StringTokenizer(str, "-", false);
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            while (st.hasMoreTokens()) {
+                final int i = Integer.parseInt(st.nextToken());
+                bos.write((byte) i);
+            }
+            return bos.toByteArray();
+        }
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/encrypt/AsymmetricEncryption.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/encrypt/AsymmetricEncryption.java
@@ -1,23 +1,22 @@
-/*
- *  Copyright (C) 2015 Claudius Teodorescu
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/encrypt/SymmetricEncryption.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/encrypt/SymmetricEncryption.java
@@ -1,23 +1,22 @@
-/*
- *  Copyright (C) 2011 Claudius Teodorescu
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
  *
- *  This program is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public License
- *  as published by the Free Software Foundation; either version 2
- *  of the License, or (at your option) any later version.
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Lesser General Public License for more details.
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
- *
- *  $Id$
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
-
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/encrypt/SymmetricEncryption.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/encrypt/SymmetricEncryption.java
@@ -21,9 +21,11 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 import java.util.StringTokenizer;
 
 import javax.crypto.BadPaddingException;
@@ -35,121 +37,116 @@ import javax.crypto.spec.SecretKeySpec;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
- * 
  * @author Claudius Teodorescu <claudius.teodorescu@gmail.com>
  */
 public class SymmetricEncryption {
 
-	public static String encryptString(String input, String plainKey, String transformationName, String iv, String provider) throws Exception {
+    public static String encryptString(final String input, final String plainKey, final String transformationName, final String iv, final String provider) throws Exception {
+        final String algorithm = (transformationName.contains("/")) ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
+        final String actualProvider = Optional.ofNullable(provider)
+                .filter(str -> !str.isEmpty())
+                .orElse("SunJCE");    // default to SunJCE
 
-		IvParameterSpec ivSpec = null;
-		String algorithm = (transformationName.contains("/")) ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
-		provider = provider.equals("") ? "SunJCE" : provider;
-		Cipher cipher = null;
+        final Cipher cipher;
+        try {
+            cipher = Cipher.getInstance(transformationName, actualProvider);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        } catch (final NoSuchPaddingException ex) {
+            throw new Exception(ErrorMessages.error_noPadding);
+        }
 
-		try {
-			cipher = Cipher.getInstance(transformationName, provider);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		} catch (NoSuchPaddingException ex) {
-			throw new Exception(ErrorMessages.error_noPadding);
-		}
+        final SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(UTF_8), algorithm);
+        if (transformationName.contains("/")) {
+            final IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes(UTF_8), 0, 16);
+            try {
+                cipher.init(Cipher.ENCRYPT_MODE, skeySpec, ivSpec);
+            } catch (InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        } else {
+            try {
+                cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
+            } catch (final InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        }
 
-		SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(StandardCharsets.UTF_8), algorithm);
+        try {
+            final byte[] resultBytes = cipher.doFinal(input.getBytes());
+            return getString(resultBytes);
+        } catch (final IllegalBlockSizeException ex) {
+            throw new Exception(ErrorMessages.error_blockSize);
+        } catch (final BadPaddingException ex) {
+            throw new Exception(ErrorMessages.error_incorrectPadding);
+        }
+    }
 
-		if (transformationName.contains("/")) {
-			ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8), 0, 16);
-			try {
-				cipher.init(Cipher.ENCRYPT_MODE, skeySpec, ivSpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		} else {
-			try {
-				cipher.init(Cipher.ENCRYPT_MODE, skeySpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		}
+    public static String decryptString(final String encryptedInput, final String plainKey, final String transformationName, final String iv, final String provider) throws Exception {
+        final String algorithm = (transformationName.contains("/")) ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
+        final String actualProvider = Optional.ofNullable(provider)
+                .filter(str -> !str.isEmpty())
+                .orElse("SunJCE");    // default to SunJCE
 
-		byte[] resultBytes = null;
-		try {
-			resultBytes = cipher.doFinal(input.getBytes());
-		} catch (IllegalBlockSizeException ex) {
-			throw new Exception(ErrorMessages.error_blockSize);
-		} catch (BadPaddingException ex) {
-			throw new Exception(ErrorMessages.error_incorrectPadding);
-		}
+        final Cipher cipher;
+        try {
+            cipher = Cipher.getInstance(transformationName, actualProvider);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new Exception(ErrorMessages.error_unknownAlgorithm);
+        } catch (final NoSuchPaddingException ex) {
+            throw new Exception(ErrorMessages.error_noPadding);
+        }
 
-		return getString(resultBytes);
-	}
+        final SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(StandardCharsets.UTF_8), algorithm);
+        if (transformationName.contains("/")) {
+            final IvParameterSpec ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8), 0, 16);
+            try {
+                cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
+            } catch (final InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        } else {
+            try {
+                cipher.init(Cipher.DECRYPT_MODE, skeySpec);
+            } catch (final InvalidKeyException ex) {
+                throw new Exception(ErrorMessages.error_cryptoKey);
+            }
+        }
+        try {
+            final byte[] resultBytes = cipher.doFinal(getBytes(encryptedInput));
+            return new String(resultBytes, UTF_8);
+        } catch (final IllegalBlockSizeException ex) {
+            throw new Exception(ErrorMessages.error_blockSize);
+        } catch (final BadPaddingException ex) {
+            throw new Exception(ErrorMessages.error_incorrectPadding);
+        }
+    }
 
-	public static String decryptString(String encryptedInput, String plainKey, String transformationName, String iv, String provider) throws Exception {
+    public static String getString(final byte[] bytes) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < bytes.length; i++) {
+            final byte b = bytes[i];
+            sb.append((int) (0x00FF & b));
+            if (i + 1 < bytes.length) {
+                sb.append("-");
+            }
+        }
+        return sb.toString();
+    }
 
-		IvParameterSpec ivSpec = null;
-		String algorithm = (transformationName.contains("/")) ? transformationName.substring(0, transformationName.indexOf("/")) : transformationName;
-		provider = provider.equals("") ? "SunJCE" : provider;
-		Cipher cipher = null;
-
-		try {
-			cipher = Cipher.getInstance(transformationName, provider);
-		} catch (NoSuchAlgorithmException ex) {
-			throw new Exception(ErrorMessages.error_unknownAlgorithm);
-		} catch (NoSuchPaddingException ex) {
-			throw new Exception(ErrorMessages.error_noPadding);
-		}
-
-		SecretKeySpec skeySpec = new SecretKeySpec(plainKey.getBytes(StandardCharsets.UTF_8), algorithm);
-
-		if (transformationName.contains("/")) {
-			ivSpec = new IvParameterSpec(iv.getBytes(StandardCharsets.UTF_8), 0, 16);
-			try {
-				cipher.init(Cipher.DECRYPT_MODE, skeySpec, ivSpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		} else {
-			try {
-				cipher.init(Cipher.DECRYPT_MODE, skeySpec);
-			} catch (InvalidKeyException ex) {
-				throw new Exception(ErrorMessages.error_cryptoKey);
-			}
-		}
-
-		byte[] resultBytes = null;
-		try {
-			resultBytes = cipher.doFinal(getBytes(encryptedInput));
-		} catch (IllegalBlockSizeException ex) {
-			throw new Exception(ErrorMessages.error_blockSize);
-		} catch (BadPaddingException ex) {
-			throw new Exception(ErrorMessages.error_incorrectPadding);
-		}
-
-		return new String(resultBytes);
-	}
-
-	public static String getString(byte[] bytes) {
-		StringBuffer sb = new StringBuffer();
-		for (int i = 0; i < bytes.length; i++) {
-			byte b = bytes[i];
-			sb.append((int) (0x00FF & b));
-			if (i + 1 < bytes.length) {
-				sb.append("-");
-			}
-		}
-		return sb.toString();
-	}
-
-	public static byte[] getBytes(String str) {
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		StringTokenizer st = new StringTokenizer(str, "-", false);
-		while (st.hasMoreTokens()) {
-			int i = Integer.parseInt(st.nextToken());
-			bos.write((byte) i);
-		}
-		return bos.toByteArray();
-	}
+    public static byte[] getBytes(final String str) throws IOException {
+        final StringTokenizer st = new StringTokenizer(str, "-", false);
+        try (final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            while (st.hasMoreTokens()) {
+                final int i = Integer.parseInt(st.nextToken());
+                bos.write((byte) i);
+            }
+            return bos.toByteArray();
+        }
+    }
 
 }
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/keyManagement/GenerateKeyPair.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/keyManagement/GenerateKeyPair.java
@@ -9,45 +9,42 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Arrays;
 
 import ro.kuberam.libs.java.crypto.randomSequencesGeneration.RandomNumber;
+
 import java.util.Base64;
 
 public class GenerateKeyPair {
 
-	public static KeyPair generate(String algorithm) throws Exception {
-		KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance(algorithm);
-		keyGenerator.initialize(1024, RandomNumber.generate("SHA1PRNG", "SUN"));
+    public static KeyPair generate(final String algorithm) throws Exception {
+        final KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance(algorithm);
+        keyGenerator.initialize(1024, RandomNumber.generate("SHA1PRNG", "SUN"));
+        return keyGenerator.generateKeyPair();
+    }
 
-		return (keyGenerator.generateKeyPair());
-	}
+    public static KeyPair generate(final long seed, final String algorithm, final String provider) throws Exception {
+        final KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance(algorithm);
+        keyGenerator.initialize(1024, RandomNumber.generate(seed, "SHA1PRNG", provider));
+        return keyGenerator.generateKeyPair();
+    }
 
-	public static KeyPair generate(long seed, String algorithm, String provider) throws Exception {
-		KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance(algorithm);
-		keyGenerator.initialize(1024, RandomNumber.generate(seed, "SHA1PRNG", provider));
+    public static String savePrivateKey(final PrivateKey priv) throws GeneralSecurityException {
+        final KeyFactory fact = KeyFactory.getInstance("RSA");
+        final PKCS8EncodedKeySpec spec = fact.getKeySpec(priv, PKCS8EncodedKeySpec.class);
+        final byte[] packed = spec.getEncoded();
+        final String key64 = Base64.getEncoder().encodeToString(packed);
+        Arrays.fill(packed, (byte) 0);
+        return key64;
+    }
 
-		return (keyGenerator.generateKeyPair());
-	}
+    public static void main(final String args[]) throws Exception {
+        final KeyPair keyPair = generate("RSA");
 
-	public static String savePrivateKey(PrivateKey priv) throws GeneralSecurityException {
-		KeyFactory fact = KeyFactory.getInstance("RSA");
-		PKCS8EncodedKeySpec spec = fact.getKeySpec(priv, PKCS8EncodedKeySpec.class);
-		byte[] packed = spec.getEncoded();
-		String key64 = Base64.getEncoder().encodeToString(packed);
+        System.out.println("Private key:\n" + Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
 
-		Arrays.fill(packed, (byte) 0);
-		return key64;
-	}
+        // System.out.println("Private key:\n" +
+        // savePrivateKey(keyPair.getPrivate()));
 
-	public static void main(String args[]) throws Exception {
-
-		KeyPair keyPair = generate("RSA");
-
-		System.out.println("Private key:\n" + Base64.getEncoder().encodeToString(keyPair.getPrivate().getEncoded()));
-
-		// System.out.println("Private key:\n" +
-		// savePrivateKey(keyPair.getPrivate()));
-
-		System.out.println("Public key:\n" + Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
-	}
+        System.out.println("Public key:\n" + Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+    }
 
 }
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/keyManagement/GenerateKeyPair.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/keyManagement/GenerateKeyPair.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.keyManagement;
 
 import java.security.GeneralSecurityException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/ListProviders.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/ListProviders.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 import java.io.IOException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/ListProviders.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/ListProviders.java
@@ -1,10 +1,10 @@
 package ro.kuberam.libs.java.crypto.providers;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -14,72 +14,65 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import ro.kuberam.libs.java.crypto.ExpathCryptoModule;
 
 public class ListProviders {
-	private static final Logger log = Logger.getLogger(ListProviders.class);
-	private static String moduleNsUri = "";
-	static {
-		moduleNsUri = ExpathCryptoModule.NAMESPACE_URI;
-	}
-	private static String modulePrefix = "";
-	static {
-		modulePrefix = ExpathCryptoModule.PREFIX;
-	}
+    private static final Logger LOG = LogManager.getLogger(ListProviders.class);
+    private static final String moduleNsUri = ExpathCryptoModule.NAMESPACE_URI;
+    private static final String modulePrefix = ExpathCryptoModule.PREFIX;
 
-	public static StreamResult listProviders() throws XMLStreamException,
-			FactoryConfigurationError {
-		long startTime = new Date().getTime();
+    public static StreamResult listProviders() throws XMLStreamException,
+            FactoryConfigurationError, IOException {
+        final long startTime = new Date().getTime();
 
-		StringWriter writer = new StringWriter();
-		XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance()
-				.createXMLStreamWriter(writer);
-		xmlWriter.setPrefix(modulePrefix, moduleNsUri);
-		xmlWriter.writeStartDocument();
-		xmlWriter.writeStartElement(modulePrefix + ":providers-list");
-		xmlWriter.writeNamespace(modulePrefix, moduleNsUri);
-		for (Provider provider : Security.getProviders()) {
-			xmlWriter.writeStartElement(modulePrefix + ":provider");
-			xmlWriter.writeAttribute("name", provider.getName());			
-			xmlWriter.writeAttribute("version", Double.toString(provider.getVersion()));
-			Set keys = provider.keySet();
-			Set result = new HashSet();
-			
-			System.out.println(provider.elements().nextElement().toString());
+        try (final StringWriter writer = new StringWriter()) {
+            final XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance()
+                    .createXMLStreamWriter(writer);
+            xmlWriter.setPrefix(modulePrefix, moduleNsUri);
+            xmlWriter.writeStartDocument();
+            xmlWriter.writeStartElement(modulePrefix + ":providers-list");
+            xmlWriter.writeNamespace(modulePrefix, moduleNsUri);
 
-			for (Iterator it = keys.iterator(); it.hasNext();) {
+            for (final Provider provider : Security.getProviders()) {
+                xmlWriter.writeStartElement(modulePrefix + ":provider");
+                xmlWriter.writeAttribute("name", provider.getName());
+                xmlWriter.writeAttribute("version", Double.toString(provider.getVersion()));
+                final Set keys = provider.keySet();
 
-				String key = (String) it.next();
-				key = key.split(" ")[0];
+                System.out.println(provider.elements().nextElement().toString());
 
-				if (key.startsWith("Alg.Alias")) {
-					// Strip the alias
-					key = key.substring(10);
-				}
+                for (Iterator it = keys.iterator(); it.hasNext(); ) {
 
-				int ix = key.indexOf('.');
-				//System.out.println(key);
-				result.add(key.substring(0, ix));
-				
-				
-			}			
-			Object[] array = result.toArray(new String[result.size()]);
-			
-			
-			xmlWriter.writeEndElement();
-		}
-		xmlWriter.writeEndElement();
-		xmlWriter.writeEndDocument();
-		xmlWriter.close();
+                    String key = (String) it.next();
+                    key = key.split(" ")[0];
 
-		StreamResult resultAsStreamResult = new StreamResult(writer);
-		log.info("The list with cryptographic providers was generated in "
-				+ (new Date().getTime() - startTime) + " ms.");
+                    if (key.startsWith("Alg.Alias")) {
+                        // Strip the alias
+                        key = key.substring(10);
+                    }
 
-		return resultAsStreamResult;
-	}
+                    final int ix = key.indexOf('.');
+                    //System.out.println(key);
+
+
+                }
+                xmlWriter.writeEndElement();
+            }
+            xmlWriter.writeEndElement();
+            xmlWriter.writeEndDocument();
+            xmlWriter.close();
+
+            final StreamResult resultAsStreamResult = new StreamResult(writer);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The list with cryptographic providers was generated in "
+                        + (new Date().getTime() - startTime) + " ms.");
+            }
+
+            return resultAsStreamResult;
+        }
+    }
 
 }
 

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/ListServices.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/ListServices.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 /**

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/ListServices.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/ListServices.java
@@ -1,10 +1,10 @@
 package ro.kuberam.libs.java.crypto.providers;
 
 /**
- *
  * @author claudius
  */
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.security.Provider;
 import java.security.Security;
@@ -16,45 +16,42 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.log4j.Logger;
-
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import ro.kuberam.libs.java.crypto.ExpathCryptoModule;
 
 public class ListServices {
-	private static final Logger log = Logger.getLogger(ListServices.class);
-	private static String moduleNsUri = "";
-	private static String modulePrefix = "";
+    private static final Logger LOG = LogManager.getLogger(ListServices.class);
+    private static final String moduleNsUri = ExpathCryptoModule.NAMESPACE_URI;
+    private static final String modulePrefix = ExpathCryptoModule.PREFIX;
 
-	static {
-		moduleNsUri = ExpathCryptoModule.NAMESPACE_URI;
-		modulePrefix = ExpathCryptoModule.PREFIX;
-	}
+    public static StreamResult listServices(final String providerName) throws XMLStreamException, FactoryConfigurationError, IOException {
+        final long startTime = new Date().getTime();
 
-	public static StreamResult listServices(String providerName) throws XMLStreamException, FactoryConfigurationError {
-		long startTime = new Date().getTime();
+        try (final StringWriter writer = new StringWriter()) {
+            final XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(writer);
+            xmlWriter.setPrefix(modulePrefix, moduleNsUri);
+            xmlWriter.writeStartDocument();
+            xmlWriter.writeStartElement(modulePrefix + ":providers-list");
+            xmlWriter.writeNamespace(modulePrefix, moduleNsUri);
 
-		Provider[] providers = Security.getProviders();
+            for (final Provider provider : Security.getProviders()) {
+                xmlWriter.writeStartElement(modulePrefix + ":provider");
+                xmlWriter.writeCharacters(provider.getName());
+                xmlWriter.writeEndElement();
+            }
+            xmlWriter.writeEndElement();
+            xmlWriter.writeEndDocument();
+            xmlWriter.close();
 
-		StringWriter writer = new StringWriter();
-		XMLStreamWriter xmlWriter = XMLOutputFactory.newInstance().createXMLStreamWriter(writer);
-		xmlWriter.setPrefix(modulePrefix, moduleNsUri);
-		xmlWriter.writeStartDocument();
-		xmlWriter.writeStartElement(modulePrefix + ":providers-list");
-		xmlWriter.writeNamespace(modulePrefix, moduleNsUri);
-		for (Provider provider : Security.getProviders()) {
-			xmlWriter.writeStartElement(modulePrefix + ":provider");
-			xmlWriter.writeCharacters(provider.getName());
-			xmlWriter.writeEndElement();
-		}
-		xmlWriter.writeEndElement();
-		xmlWriter.writeEndDocument();
-		xmlWriter.close();
+            final StreamResult resultAsStreamResult = new StreamResult(writer);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("The list with cryptographic services for provider " + providerName + " was generated in "
+                        + (new Date().getTime() - startTime) + " ms.");
+            }
 
-		StreamResult resultAsStreamResult = new StreamResult(writer);
-		log.info("The list with cryptographic services for provider " + providerName + " was generated in "
-				+ (new Date().getTime() - startTime) + " ms.");
-
-		return resultAsStreamResult;
-	}
+            return resultAsStreamResult;
+        }
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/SetProvider.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/SetProvider.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 public class SetProvider {

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/defaultProvider/ExpathCrypto.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/defaultProvider/ExpathCrypto.java
@@ -5,124 +5,124 @@ import java.security.Provider;
 
 public class ExpathCrypto extends Provider {
 
-	private static String info = "SunJCE Provider "
-			+ "(implements DES, Triple DES, Blowfish, PBE, Diffie-Hellman, HMAC-MD5, "
-			+ "HMAC-SHA1)";
+    private static String info = "SunJCE Provider "
+            + "(implements DES, Triple DES, Blowfish, PBE, Diffie-Hellman, HMAC-MD5, "
+            + "HMAC-SHA1)";
 
-	public ExpathCrypto() {
-		/* We are the "base64" provider */
-		super("ExpathCrypto", 1.4, info);
+    public ExpathCrypto() {
+        /* We are the "base64" provider */
+        super("ExpathCrypto", 1.4, info);
 
-		AccessController.doPrivileged(new java.security.PrivilegedAction() {
-			public Object run() {
+        AccessController.doPrivileged(new java.security.PrivilegedAction() {
+            public Object run() {
 
 				/*
 				 * Cipher engines
 				 */
-				put("Cipher.DES", "com.sun.crypto.provider.DESCipher");
+                put("Cipher.DES", "com.sun.crypto.provider.DESCipher");
 
-				put("Cipher.DESede", "com.sun.crypto.provider.DESedeCipher");
-				put("Alg.Alias.Cipher.TripleDES", "DESede");
+                put("Cipher.DESede", "com.sun.crypto.provider.DESedeCipher");
+                put("Alg.Alias.Cipher.TripleDES", "DESede");
 
-				put("Cipher.PBEWithMD5AndDES",
-						"com.sun.crypto.provider.PBEWithMD5AndDESCipher");
-				put("Cipher.PBEWithMD5AndTripleDES",
-						"com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher");
+                put("Cipher.PBEWithMD5AndDES",
+                        "com.sun.crypto.provider.PBEWithMD5AndDESCipher");
+                put("Cipher.PBEWithMD5AndTripleDES",
+                        "com.sun.crypto.provider.PBEWithMD5AndTripleDESCipher");
 
-				put("Cipher.Blowfish", "com.sun.crypto.provider.BlowfishCipher");
+                put("Cipher.Blowfish", "com.sun.crypto.provider.BlowfishCipher");
 
 				/*
 				 * Key(pair) Generator engines
 				 */
-				put("KeyGenerator.DES",
-						"com.sun.crypto.provider.DESKeyGenerator");
+                put("KeyGenerator.DES",
+                        "com.sun.crypto.provider.DESKeyGenerator");
 
-				put("KeyGenerator.DESede",
-						"com.sun.crypto.provider.DESedeKeyGenerator");
-				put("Alg.Alias.KeyGenerator.TripleDES", "DESede");
+                put("KeyGenerator.DESede",
+                        "com.sun.crypto.provider.DESedeKeyGenerator");
+                put("Alg.Alias.KeyGenerator.TripleDES", "DESede");
 
-				put("KeyGenerator.Blowfish",
-						"com.sun.crypto.provider.BlowfishKeyGenerator");
+                put("KeyGenerator.Blowfish",
+                        "com.sun.crypto.provider.BlowfishKeyGenerator");
 
-				put("KeyGenerator.HmacMD5",
-						"com.sun.crypto.provider.HmacMD5KeyGenerator");
+                put("KeyGenerator.HmacMD5",
+                        "com.sun.crypto.provider.HmacMD5KeyGenerator");
 
-				put("KeyGenerator.HmacSHA1",
-						"com.sun.crypto.provider.HmacSHA1KeyGenerator");
+                put("KeyGenerator.HmacSHA1",
+                        "com.sun.crypto.provider.HmacSHA1KeyGenerator");
 
-				put("KeyPairGenerator.DiffieHellman",
-						"com.sun.crypto.provider.DHKeyPairGenerator");
-				put("Alg.Alias.KeyPairGenerator.DH", "DiffieHellman");
+                put("KeyPairGenerator.DiffieHellman",
+                        "com.sun.crypto.provider.DHKeyPairGenerator");
+                put("Alg.Alias.KeyPairGenerator.DH", "DiffieHellman");
 
 				/*
 				 * Algorithm parameter generation engines
 				 */
-				put("AlgorithmParameterGenerator.DiffieHellman",
-						"com.sun.crypto.provider.DHParameterGenerator");
-				put("Alg.Alias.AlgorithmParameterGenerator.DH", "DiffieHellman");
+                put("AlgorithmParameterGenerator.DiffieHellman",
+                        "com.sun.crypto.provider.DHParameterGenerator");
+                put("Alg.Alias.AlgorithmParameterGenerator.DH", "DiffieHellman");
 
 				/*
 				 * Key Agreement engines
 				 */
-				put("KeyAgreement.DiffieHellman",
-						"com.sun.crypto.provider.DHKeyAgreement");
-				put("Alg.Alias.KeyAgreement.DH", "DiffieHellman");
+                put("KeyAgreement.DiffieHellman",
+                        "com.sun.crypto.provider.DHKeyAgreement");
+                put("Alg.Alias.KeyAgreement.DH", "DiffieHellman");
 
 				/*
 				 * Algorithm Parameter engines
 				 */
-				put("AlgorithmParameters.DiffieHellman",
-						"com.sun.crypto.provider.DHParameters");
-				put("Alg.Alias.AlgorithmParameters.DH", "DiffieHellman");
+                put("AlgorithmParameters.DiffieHellman",
+                        "com.sun.crypto.provider.DHParameters");
+                put("Alg.Alias.AlgorithmParameters.DH", "DiffieHellman");
 
-				put("AlgorithmParameters.DES",
-						"com.sun.crypto.provider.DESParameters");
+                put("AlgorithmParameters.DES",
+                        "com.sun.crypto.provider.DESParameters");
 
-				put("AlgorithmParameters.DESede",
-						"com.sun.crypto.provider.DESedeParameters");
-				put("Alg.Alias.AlgorithmParameters.TripleDES", "DESede");
+                put("AlgorithmParameters.DESede",
+                        "com.sun.crypto.provider.DESedeParameters");
+                put("Alg.Alias.AlgorithmParameters.TripleDES", "DESede");
 
-				put("AlgorithmParameters.PBE",
-						"com.sun.crypto.provider.PBEParameters");
-				put("Alg.Alias.AlgorithmParameters.PBEWithMD5AndDES", "PBE");
+                put("AlgorithmParameters.PBE",
+                        "com.sun.crypto.provider.PBEParameters");
+                put("Alg.Alias.AlgorithmParameters.PBEWithMD5AndDES", "PBE");
 
-				put("AlgorithmParameters.Blowfish",
-						"com.sun.crypto.provider.BlowfishParameters");
+                put("AlgorithmParameters.Blowfish",
+                        "com.sun.crypto.provider.BlowfishParameters");
 
 				/*
 				 * Key factories
 				 */
-				put("KeyFactory.DiffieHellman",
-						"com.sun.crypto.provider.DHKeyFactory");
-				put("Alg.Alias.KeyFactory.DH", "DiffieHellman");
+                put("KeyFactory.DiffieHellman",
+                        "com.sun.crypto.provider.DHKeyFactory");
+                put("Alg.Alias.KeyFactory.DH", "DiffieHellman");
 
 				/*
 				 * Secret-key factories
 				 */
-				put("SecretKeyFactory.DES",
-						"com.sun.crypto.provider.DESKeyFactory");
+                put("SecretKeyFactory.DES",
+                        "com.sun.crypto.provider.DESKeyFactory");
 
-				put("SecretKeyFactory.DESede",
-						"com.sun.crypto.provider.DESedeKeyFactory");
-				put("Alg.Alias.SecretKeyFactory.TripleDES", "DESede");
+                put("SecretKeyFactory.DESede",
+                        "com.sun.crypto.provider.DESedeKeyFactory");
+                put("Alg.Alias.SecretKeyFactory.TripleDES", "DESede");
 
-				put("SecretKeyFactory.PBEWithMD5AndDES",
-						"com.sun.crypto.provider.PBEKeyFactory");
+                put("SecretKeyFactory.PBEWithMD5AndDES",
+                        "com.sun.crypto.provider.PBEKeyFactory");
 
 				/*
 				 * MAC
 				 */
-				put("Mac.HmacMD5", "com.sun.crypto.provider.HmacMD5");
-				put("Mac.HmacSHA1", "com.sun.crypto.provider.HmacSHA1");
+                put("Mac.HmacMD5", "com.sun.crypto.provider.HmacMD5");
+                put("Mac.HmacSHA1", "com.sun.crypto.provider.HmacSHA1");
 
 				/*
 				 * KeyStore
 				 */
-				put("KeyStore.JCEKS", "com.sun.crypto.provider.JceKeyStore");
+                put("KeyStore.JCEKS", "com.sun.crypto.provider.JceKeyStore");
 
-				return null;
-			}
-		});
-	}
+                return null;
+            }
+        });
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/providers/defaultProvider/ExpathCrypto.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/providers/defaultProvider/ExpathCrypto.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers.defaultProvider;
 
 import java.security.AccessController;

--- a/src/main/java/ro/kuberam/libs/java/crypto/randomSequencesGeneration/RandomNumber.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/randomSequencesGeneration/RandomNumber.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.randomSequencesGeneration;
 
 import java.security.SecureRandom;

--- a/src/main/java/ro/kuberam/libs/java/crypto/randomSequencesGeneration/RandomNumber.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/randomSequencesGeneration/RandomNumber.java
@@ -4,25 +4,21 @@ import java.security.SecureRandom;
 
 public class RandomNumber {
 
-	public static SecureRandom generate(long seed, String algorithm, String provider)
-			throws Exception {
-		SecureRandom randomNumber = SecureRandom.getInstance(algorithm, provider);
-		randomNumber.setSeed(seed);
+    public static SecureRandom generate(final long seed, final String algorithm, final String provider)
+            throws Exception {
+        final SecureRandom randomNumber = SecureRandom.getInstance(algorithm, provider);
+        randomNumber.setSeed(seed);
+        return randomNumber;
+    }
 
-		return randomNumber;
-	}
+    public static SecureRandom generate(final String algorithm, final String provider) throws Exception {
+        final SecureRandom randomNumber = SecureRandom.getInstance(algorithm, provider);
+        return randomNumber;
+    }
 
-	public static SecureRandom generate(String algorithm, String provider) throws Exception {
-		SecureRandom randomNumber = SecureRandom.getInstance(algorithm, provider);
-
-		return randomNumber;
-	}
-
-	public static void main(String args[]) throws Exception {
-
-		SecureRandom randomNumber = generate(1008, "SHA1PRNG", "SUN");
-
-		System.out.println("Random number:\n" + randomNumber.nextLong());
-	}
+    public static void main(final String args[]) throws Exception {
+        final SecureRandom randomNumber = generate(1008, "SHA1PRNG", "SUN");
+        System.out.println("Random number:\n" + randomNumber.nextLong());
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/AddEntry.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/AddEntry.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 import java.security.Key;

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/AddEntry.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/AddEntry.java
@@ -4,27 +4,27 @@ import java.security.Key;
 import java.security.cert.Certificate;
 
 public class AddEntry {
-	
-	public boolean add() {
-		
-		boolean added = true;
-		
-		return added;
-	}
-	
-	private boolean addKey(String alias, Key key, char[] password, Certificate[] certificateChain) {
-		
-		boolean added = true;
-		
-		return added;
-	}
-	
-	private boolean addCertificate(String alias, Certificate certificate) {
-		
-		boolean added = true;
-		
-		return added;
-	}
+
+    public boolean add() {
+
+        boolean added = true;
+
+        return added;
+    }
+
+    private boolean addKey(final String alias, final Key key, final char[] password, final Certificate[] certificateChain) {
+
+        boolean added = true;
+
+        return added;
+    }
+
+    private boolean addCertificate(final String alias, final Certificate certificate) {
+
+        boolean added = true;
+
+        return added;
+    }
 }
 
 //import java.security.*;
@@ -100,7 +100,6 @@ public class AddEntry {
 //		}
 //	}
 //}
-
 
 
 //import java.io.*;

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ConvertSecureStore.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ConvertSecureStore.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class ConvertSecureStore {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/CreateSecureStore.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/CreateSecureStore.java
@@ -9,24 +9,22 @@ import java.security.cert.CertificateException;
 
 public class CreateSecureStore {
 
-	public static byte[] create(String password) throws NoSuchAlgorithmException, CertificateException,
-			IOException, KeyStoreException {
-		
-		KeyStore ks = KeyStore.getInstance("JKS");
-		char[] passwordCharArray = password.toCharArray();
+    public static byte[] create(final String password) throws NoSuchAlgorithmException, CertificateException,
+            IOException, KeyStoreException {
 
-		ks.load(null, passwordCharArray);
+        final KeyStore ks = KeyStore.getInstance("JKS");
+        final char[] passwordCharArray = password.toCharArray();
 
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ks.load(null, passwordCharArray);
 
-		ks.store(baos, passwordCharArray);
-		baos.close();
-		
-		return baos.toByteArray();
-	}
-	
-	   public static void main(String[] args) throws Exception {
-		   System.out.println(new String(create("password")));
-	   }
+        try (final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            ks.store(baos, passwordCharArray);
+            return baos.toByteArray();
+        }
+    }
+
+    public static void main(final String[] args) throws Exception {
+        System.out.println(new String(create("password")));
+    }
 
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/CreateSecureStore.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/CreateSecureStore.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 import java.io.ByteArrayOutputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/DeleteEntry.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/DeleteEntry.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class DeleteEntry {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetEntry.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetEntry.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class GetEntry {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetEntryMetadata.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetEntryMetadata.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class GetEntryMetadata {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetSecureStoreMetadata.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/GetSecureStoreMetadata.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class GetSecureStoreMetadata {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ListTrustedCertificateAuthorities.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ListTrustedCertificateAuthorities.java
@@ -1,8 +1,10 @@
 package ro.kuberam.libs.java.crypto.secureStorage;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -14,34 +16,28 @@ import java.security.cert.X509Certificate;
 import java.util.Iterator;
 
 public class ListTrustedCertificateAuthorities {
-	
-	public static void main(String[] args) {
-        try {
-            // Load the JDK's cacerts keystore file
-            String filename = System.getProperty("java.home") + "/lib/security/cacerts".replace('/', File.separatorChar);
-            FileInputStream is = new FileInputStream(filename);
-            KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-            String password = "changeit";
+
+    public static void main(final String[] args) {
+        // Load the JDK's cacerts keystore file
+        final Path filename = Paths.get(System.getProperty("java.home"), "lib", "security", "cacerts");
+        try (final InputStream is = Files.newInputStream(filename)) {
+            final KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+            final String password = "changeit";
             keystore.load(is, password.toCharArray());
 
             // This class retrieves the most-trusted CAs from the keystore
-            PKIXParameters params = new PKIXParameters(keystore);
+            final PKIXParameters params = new PKIXParameters(keystore);
 
             // Get the set of trust anchors, which contain the most-trusted CA certificates
-            Iterator<TrustAnchor> it = params.getTrustAnchors().iterator();
-            while( it.hasNext() ) {
-                TrustAnchor ta = (TrustAnchor)it.next();
+            final Iterator<TrustAnchor> it = params.getTrustAnchors().iterator();
+            while (it.hasNext()) {
+                final TrustAnchor ta = (TrustAnchor) it.next();
                 // Get certificate
-                X509Certificate cert = ta.getTrustedCert();
+                final X509Certificate cert = ta.getTrustedCert();
                 System.out.println(cert.getIssuerDN());
             }
-        } catch (CertificateException e) {
-        } catch (KeyStoreException e) {
-        } catch (NoSuchAlgorithmException e) {
-        } catch (InvalidAlgorithmParameterException e) {
-        } catch (IOException e) {
-        } 
+        } catch (final CertificateException | KeyStoreException | InvalidAlgorithmParameterException | NoSuchAlgorithmException | IOException e) {
+            //what?
+        }
     }
-
-
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ListTrustedCertificateAuthorities.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ListTrustedCertificateAuthorities.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 import java.io.IOException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/LoadSecureStore.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/LoadSecureStore.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 public class LoadSecureStore {

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ReloadableX509TrustManager.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ReloadableX509TrustManager.java
@@ -1,100 +1,98 @@
 package ro.kuberam.libs.java.crypto.secureStorage;
 
-import java.awt.List;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.UUID;
 
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
 class ReloadableX509TrustManager implements X509TrustManager {
-	private final String trustStorePath;
-	private X509TrustManager trustManager;
-	private List tempCertList = new List();
+    private final String trustStorePath;
+    private X509TrustManager trustManager;
+    //private List tempCertList = new List();
 
-	public ReloadableX509TrustManager(String tspath) throws Exception {
-		this.trustStorePath = tspath;
-		reloadTrustManager();
-	}
+    public ReloadableX509TrustManager(final String tspath) throws Exception {
+        this.trustStorePath = tspath;
+        reloadTrustManager();
+    }
 
-	public X509Certificate[] getAcceptedIssuers() {
-		X509Certificate[] issuers = trustManager.getAcceptedIssuers();
-		return issuers;
-	}
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+        final X509Certificate[] issuers = trustManager.getAcceptedIssuers();
+        return issuers;
+    }
 
-	private void reloadTrustManager() throws Exception {
+    private void reloadTrustManager() throws Exception {
 
-		// load keystore from specified cert store (or default)
-		KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
-		InputStream in = new FileInputStream(trustStorePath);
-		try {
-			ts.load(in, null);
-		} finally {
-			in.close();
-		}
+        // load keystore from specified cert store (or default)
+        final KeyStore ts = KeyStore.getInstance(KeyStore.getDefaultType());
+        try (final InputStream in = Files.newInputStream(Paths.get(trustStorePath))) {
+            ts.load(in, null);
+        }
 
-		// add all temporary certs to KeyStore (ts)
-		//TODO: this below has to be commented out to work 
+        // add all temporary certs to KeyStore (ts)
+        //TODO: this below has to be commented out to work
 //		for (Certificate cert : tempCertList) {
 //			ts.setCertificateEntry(UUID.randomUUID().toString(), cert);
 //		}
 
-		// initialize a new TMF with the ts we just loaded
-		TrustManagerFactory tmf = TrustManagerFactory
-				.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-		tmf.init(ts);
+        // initialize a new TMF with the ts we just loaded
+        final TrustManagerFactory tmf = TrustManagerFactory
+                .getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ts);
 
-		// acquire X509 trust manager from factory
-		TrustManager tms[] = tmf.getTrustManagers();
-		for (int i = 0; i < tms.length; i++) {
-			if (tms[i] instanceof X509TrustManager) {
-				trustManager = (X509TrustManager) tms[i];
-				return;
-			}
-		}
+        // acquire X509 trust manager from factory
+        final TrustManager tms[] = tmf.getTrustManagers();
+        for (int i = 0; i < tms.length; i++) {
+            if (tms[i] instanceof X509TrustManager) {
+                trustManager = (X509TrustManager) tms[i];
+                return;
+            }
+        }
 
-		throw new NoSuchAlgorithmException(
-				"No X509TrustManager in TrustManagerFactory");
-	}
+        throw new NoSuchAlgorithmException(
+                "No X509TrustManager in TrustManagerFactory");
+    }
 
-	private void addServerCertAndReload(Certificate cert, boolean permanent) {
-		try {
-			if (permanent) {
-				// import the cert into file trust store
-				// Google "java keytool source" or just ...
-				Runtime.getRuntime().exec("keytool -importcert ...");
-			} else {
-				//TODO: this below has to be commented out to work 
+    private void addServerCertAndReload(final Certificate cert, final boolean permanent) {
+        try {
+            if (permanent) {
+                // import the cert into file trust store
+                // Google "java keytool source" or just ...
+                Runtime.getRuntime().exec("keytool -importcert ...");
+            } else {
+                //TODO: this below has to be commented out to work
 //				tempCertList.add(cert);
-			}
-			reloadTrustManager();
-		} catch (Exception ex) { /* ... */
-		}
-	}
+            }
+            reloadTrustManager();
+        } catch (final Exception ex) { /* ... */
+            //what?
+        }
+    }
 
-	//@Override
-	public void checkClientTrusted(X509Certificate[] chain, String authType)
-			throws CertificateException {
-		trustManager.checkClientTrusted(chain, authType);
-		
-	}
+    @Override
+    public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+            throws CertificateException {
+        trustManager.checkClientTrusted(chain, authType);
 
-	//@Override
-	public void checkServerTrusted(X509Certificate[] chain, String authType)
-			throws CertificateException {
-		try {
-			trustManager.checkServerTrusted(chain, authType);
-		} catch (CertificateException cx) {
-			addServerCertAndReload(chain[0], true);
-			trustManager.checkServerTrusted(chain, authType);
-		}
-		
-	}
+    }
+
+    @Override
+    public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+            throws CertificateException {
+        try {
+            trustManager.checkServerTrusted(chain, authType);
+        } catch (final CertificateException cx) {
+            addServerCertAndReload(chain[0], true);
+            trustManager.checkServerTrusted(chain, authType);
+        }
+
+    }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ReloadableX509TrustManager.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/secureStorage/ReloadableX509TrustManager.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.secureStorage;
 
 import java.io.InputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/GenerateCertificationRequest.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/GenerateCertificationRequest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.toDo;
 
 //import java.io.ByteArrayOutputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/ListAvailableCryptographicServices.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/ListAvailableCryptographicServices.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 /*
  * To change this template, choose Tools | Templates
  * and open the template in the editor.

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/ListAvailableCryptographicServices.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/ListAvailableCryptographicServices.java
@@ -6,7 +6,6 @@
 package ro.kuberam.libs.java.crypto.toDo;
 
 /**
- *
  * @author claudius
  */
 // -----------------------------------------------------------------------------
@@ -55,8 +54,8 @@ import java.util.Iterator;
  * <code>SecureRandom.SHA1PRNG</code>
  * -----------------------------------------------------------------------------
  * @version 1.0
- * @author  Jeffrey M. Hunter  (jhunter@idevelopment.info)
- * @author  http://www.idevelopment.info
+ * @author Jeffrey M. Hunter  (jhunter@idevelopment.info)
+ * @author http://www.idevelopment.info
  * -----------------------------------------------------------------------------
  */
 
@@ -69,18 +68,18 @@ public class ListAvailableCryptographicServices {
      */
     private static String[] getServiceTypes() {
 
-        Set result = new HashSet();
+        final Set<String> result = new HashSet<>();
 
         // All providers
-        Provider[] providers = Security.getProviders();
-        for (int i=0; i<providers.length; i++) {
+        final Provider[] providers = Security.getProviders();
+        for (int i = 0; i < providers.length; i++) {
 
             // Get services provided by each provider
-            Set keys = providers[i].keySet();
+            final Set keys = providers[i].keySet();
 
-            for (Iterator it=keys.iterator(); it.hasNext(); ) {
+            for (final Iterator it = keys.iterator(); it.hasNext(); ) {
 
-                String key = (String)it.next();
+                String key = (String) it.next();
                 key = key.split(" ")[0];
 
                 if (key.startsWith("Alg.Alias")) {
@@ -88,13 +87,13 @@ public class ListAvailableCryptographicServices {
                     key = key.substring(10);
                 }
 
-                int ix = key.indexOf('.');
-                result.add(key.substring(0,ix));
+                final int ix = key.indexOf('.');
+                result.add(key.substring(0, ix));
             }
 
         }
 
-        return (String[])result.toArray(new String[result.size()]);
+        return result.toArray(new String[result.size()]);
 
     }
 
@@ -107,20 +106,20 @@ public class ListAvailableCryptographicServices {
      * @return <code>String[]</code> object that is a list of all available
      *                               service type implementations.
      */
-    private static String[] getCryptoImpls(String serviceType) {
+    private static String[] getCryptoImpls(final String serviceType) {
 
-        Set result = new HashSet();
+        final Set<String> result = new HashSet<>();
 
         // All providers
-        Provider[] providers = Security.getProviders();
-        for (int i=0; i<providers.length; i++) {
+        final Provider[] providers = Security.getProviders();
+        for (int i = 0; i < providers.length; i++) {
 
             // Get services provided by each provider
-            Set keys = providers[i].keySet();
+            final Set keys = providers[i].keySet();
 
-            for (Iterator it=keys.iterator(); it.hasNext(); ) {
+            for (final Iterator it = keys.iterator(); it.hasNext(); ) {
 
-                String key = (String)it.next();
+                String key = (String) it.next();
 
                 key = key.split(" ")[0];
 
@@ -135,7 +134,7 @@ public class ListAvailableCryptographicServices {
 
         }
 
-        return (String[])result.toArray(new String[result.size()]);
+        return result.toArray(new String[result.size()]);
 
     }
 
@@ -149,10 +148,10 @@ public class ListAvailableCryptographicServices {
         System.out.println("Service Types");
         System.out.println("-------------");
 
-        String[] serviceTypes = getServiceTypes();
+        final String[] serviceTypes = getServiceTypes();
         Arrays.sort(serviceTypes);
 
-        for (int i=0; i<serviceTypes.length; i++) {
+        for (int i = 0; i < serviceTypes.length; i++) {
             System.out.println("  - " + serviceTypes[i]);
         }
         System.out.println();
@@ -169,18 +168,18 @@ public class ListAvailableCryptographicServices {
         System.out.println("Service Type Implementations");
         System.out.println("----------------------------");
 
-        String[] serviceTypes = getServiceTypes();
+        final String[] serviceTypes = getServiceTypes();
         Arrays.sort(serviceTypes);
 
-        for (int i=0; i<serviceTypes.length; i++) {
+        for (int i = 0; i < serviceTypes.length; i++) {
 
             System.out.println();
             System.out.println("  - " + serviceTypes[i]);
 
-            String[] serviceTypeImpls = getCryptoImpls(serviceTypes[i]);
+            final String[] serviceTypeImpls = getCryptoImpls(serviceTypes[i]);
             Arrays.sort(serviceTypeImpls);
 
-            for (int j=0; j<serviceTypeImpls.length; j++) {
+            for (int j = 0; j < serviceTypeImpls.length; j++) {
                 System.out.println("      " + serviceTypeImpls[j]);
             }
 
@@ -190,7 +189,7 @@ public class ListAvailableCryptographicServices {
     }
 
 
-    public static void main(String[] args) {
+    public static void main(final String[] args) {
         listServiceTypes();
         listCryptoImpls();
     }

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/Rfc2898DeriveBytes.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/Rfc2898DeriveBytes.java
@@ -6,78 +6,88 @@ import java.security.NoSuchAlgorithmException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
- * RFC 2898 password derivation compatible with .NET Rfc2898DeriveBytes class. 
+ * RFC 2898 password derivation compatible with .NET Rfc2898DeriveBytes class.
  * http://www.jmedved.com/2010/05/java-rfc2898derivebytes/
  */
 public class Rfc2898DeriveBytes {
 
-    private Mac _hmacSha1;
-    private byte[] _salt;
-    private int _iterationCount;
+    private final Mac _hmacSha1;
+    private final byte[] _salt;
+    private final int _iterationCount;
 
     private byte[] _buffer = new byte[20];
     private int _bufferStartIndex = 0;
     private int _bufferEndIndex = 0;
     private int _block = 1;
 
-    
+
     /**
      * Creates new instance.
-     * @param password The password used to derive the key.
-     * @param salt The key salt used to derive the key.
+     *
+     * @param password   The password used to derive the key.
+     * @param salt       The key salt used to derive the key.
      * @param iterations The number of iterations for the operation.
      * @throws NoSuchAlgorithmException HmacSHA1 algorithm cannot be found.
-     * @throws InvalidKeyException Salt must be 8 bytes or more. -or- Password cannot be null.
+     * @throws InvalidKeyException      Salt must be 8 bytes or more. -or- Password cannot be null.
      */
-    public Rfc2898DeriveBytes(byte[] password, byte[] salt, int iterations) throws NoSuchAlgorithmException, InvalidKeyException {
-    	if ((salt == null) || (salt.length < 8)) { throw new InvalidKeyException("Salt must be 8 bytes or more."); }
-    	if (password == null) { throw new InvalidKeyException("Password cannot be null."); }
+    public Rfc2898DeriveBytes(final byte[] password, final byte[] salt, final int iterations) throws NoSuchAlgorithmException, InvalidKeyException {
+        if ((salt == null) || (salt.length < 8)) {
+            throw new InvalidKeyException("Salt must be 8 bytes or more.");
+        }
+        if (password == null) {
+            throw new InvalidKeyException("Password cannot be null.");
+        }
         this._salt = salt;
         this._iterationCount = iterations;
         this._hmacSha1 = Mac.getInstance("HmacSHA1");
         this._hmacSha1.init(new SecretKeySpec(password, "HmacSHA1"));
     }
-    
+
     /**
      * Creates new instance.
-     * @param password The password used to derive the key.
-     * @param salt The key salt used to derive the key.
+     *
+     * @param password   The password used to derive the key.
+     * @param salt       The key salt used to derive the key.
      * @param iterations The number of iterations for the operation.
-     * @throws NoSuchAlgorithmException HmacSHA1 algorithm cannot be found.
-     * @throws InvalidKeyException Salt must be 8 bytes or more. -or- Password cannot be null.
-     * @throws UnsupportedEncodingException UTF-8 encoding is not supported. 
+     * @throws NoSuchAlgorithmException     HmacSHA1 algorithm cannot be found.
+     * @throws InvalidKeyException          Salt must be 8 bytes or more. -or- Password cannot be null.
+     * @throws UnsupportedEncodingException UTF-8 encoding is not supported.
      */
-    public Rfc2898DeriveBytes(String password, byte[] salt, int iterations) throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException  {
-    	this(password.getBytes("UTF8"), salt, iterations);
+    public Rfc2898DeriveBytes(final String password, final byte[] salt, final int iterations) throws InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        this(password.getBytes(UTF_8), salt, iterations);
     }
 
     /**
      * Creates new instance.
+     *
      * @param password The password used to derive the key.
-     * @param salt The key salt used to derive the key.
-     * @throws NoSuchAlgorithmException HmacSHA1 algorithm cannot be found.
-     * @throws InvalidKeyException Salt must be 8 bytes or more. -or- Password cannot be null.
-     * @throws UnsupportedEncodingException UTF-8 encoding is not supported. 
+     * @param salt     The key salt used to derive the key.
+     * @throws NoSuchAlgorithmException     HmacSHA1 algorithm cannot be found.
+     * @throws InvalidKeyException          Salt must be 8 bytes or more. -or- Password cannot be null.
+     * @throws UnsupportedEncodingException UTF-8 encoding is not supported.
      */
-    public Rfc2898DeriveBytes(String password, byte[] salt) throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException {
-    	this(password, salt, 0x3e8);
+    public Rfc2898DeriveBytes(final String password, final byte[] salt) throws NoSuchAlgorithmException, InvalidKeyException, UnsupportedEncodingException {
+        this(password, salt, 0x3e8);
     }
 
 
     /**
      * Returns a pseudo-random key from a password, salt and iteration count.
+     *
      * @param count Number of bytes to return.
      * @return Byte array.
      */
-    public byte[] getBytes(int count) {
-        byte[] result = new byte[count];
+    public byte[] getBytes(final int count) {
+        final byte[] result = new byte[count];
         int resultOffset = 0;
-        int bufferCount = this._bufferEndIndex - this._bufferStartIndex;
+        final int bufferCount = this._bufferEndIndex - this._bufferStartIndex;
 
         if (bufferCount > 0) { //if there is some data in buffer
             if (count < bufferCount) { //if there is enough data in buffer
-            	System.arraycopy(this._buffer, this._bufferStartIndex, result, 0, count);
+                System.arraycopy(this._buffer, this._bufferStartIndex, result, 0, count);
                 this._bufferStartIndex += count;
                 return result;
             }
@@ -87,13 +97,13 @@ public class Rfc2898DeriveBytes {
         }
 
         while (resultOffset < count) {
-            int needCount = count - resultOffset;
+            final int needCount = count - resultOffset;
             this._buffer = this.func();
             if (needCount > 20) { //we one (or more) additional passes
-            	System.arraycopy(this._buffer, 0, result, resultOffset, 20);
+                System.arraycopy(this._buffer, 0, result, resultOffset, 20);
                 resultOffset += 20;
             } else {
-            	System.arraycopy(this._buffer, 0, result, resultOffset, needCount);
+                System.arraycopy(this._buffer, 0, result, resultOffset, needCount);
                 this._bufferStartIndex = needCount;
                 this._bufferEndIndex = 20;
                 return result;
@@ -102,7 +112,7 @@ public class Rfc2898DeriveBytes {
         return result;
     }
 
-    
+
     private byte[] func() {
         this._hmacSha1.update(this._salt, 0, this._salt.length);
         byte[] tempHash = this._hmacSha1.doFinal(getBytesFromInt(this._block));
@@ -112,7 +122,7 @@ public class Rfc2898DeriveBytes {
         for (int i = 2; i <= this._iterationCount; i++) {
             tempHash = this._hmacSha1.doFinal(tempHash);
             for (int j = 0; j < 20; j++) {
-                finalHash[j] = (byte)(finalHash[j] ^ tempHash[j]);
+                finalHash[j] = (byte) (finalHash[j] ^ tempHash[j]);
             }
         }
         if (this._block == 2147483647) {
@@ -124,8 +134,8 @@ public class Rfc2898DeriveBytes {
         return finalHash;
     }
 
-    private static byte[] getBytesFromInt(int i) {
-    	return new byte[] { (byte)(i >>> 24), (byte)(i >>> 16), (byte)(i >>> 8), (byte)i };
+    private static byte[] getBytesFromInt(final int i) {
+        return new byte[]{(byte) (i >>> 24), (byte) (i >>> 16), (byte) (i >>> 8), (byte) i};
     }
-	
+
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/Rfc2898DeriveBytes.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/Rfc2898DeriveBytes.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.toDo;
 
 import java.io.UnsupportedEncodingException;

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/SignFileExample.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/SignFileExample.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.toDo;
 
 import java.io.InputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/X509KeySelector.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/X509KeySelector.java
@@ -22,14 +22,14 @@ import javax.xml.crypto.dsig.keyinfo.*;
 /**
  * A <code>KeySelector</code> that returns {@link PublicKey}s of trusted
  * {@link X509Certificate}s stored in a {@link KeyStore}.
- *
+ * <p>
  * <p>This <code>KeySelector</code> uses the specified <code>KeyStore</code>
  * to find a trusted <code>X509Certificate</code> that matches information
  * specified in the {@link KeyInfo} passed to the {@link #select} method.
  * The public key from the first match is returned. If no match,
  * <code>null</code> is returned. See the <code>select</code> method for more
  * information.
- *
+ * <p>
  * <p>NOTE!: This X509KeySelector requires J2SE 1.4 because it uses the
  * java.security.cert.X509CertSelector & javax.security.auth.x500.X500Principal
  * classes to parse X.500 DNs and match on certificate attributes.
@@ -44,11 +44,11 @@ public class X509KeySelector extends KeySelector {
      * Creates an <code>X509KeySelector</code>.
      *
      * @param keyStore the keystore
-     * @throws KeyStoreException if the keystore has not been initialized
+     * @throws KeyStoreException    if the keystore has not been initialized
      * @throws NullPointerException if <code>keyStore</code> is
-     *    <code>null</code>
+     *                              <code>null</code>
      */
-    public X509KeySelector(KeyStore keyStore) throws KeyStoreException {
+    public X509KeySelector(final KeyStore keyStore) throws KeyStoreException {
         if (keyStore == null) {
             throw new NullPointerException("keyStore is null");
         }
@@ -59,50 +59,51 @@ public class X509KeySelector extends KeySelector {
 
     /**
      * Finds a key from the keystore satisfying the specified constraints.
-     *
+     * <p>
      * <p>This method compares data contained in {@link KeyInfo} entries
      * with information stored in the <code>KeyStore</code>. The implementation
      * iterates over the KeyInfo types and returns the first {@link PublicKey}
      * of an X509Certificate in the keystore that is compatible with the
      * specified AlgorithmMethod according to the following rules for each
      * keyinfo type:
-     *
+     * <p>
      * X509Data X509Certificate: if it contains a <code>KeyUsage</code>
-     *   extension that asserts the <code>digitalSignature</code> bit and
-     *   matches an <code>X509Certificate</code> in the <code>KeyStore</code>.
+     * extension that asserts the <code>digitalSignature</code> bit and
+     * matches an <code>X509Certificate</code> in the <code>KeyStore</code>.
      * X509Data X509IssuerSerial: if the serial number and issuer DN match an
-     *    <code>X509Certificate</code> in the <code>KeyStore</code>.
+     * <code>X509Certificate</code> in the <code>KeyStore</code>.
      * X509Data X509SubjectName: if the subject DN matches an
-     *    <code>X509Certificate</code> in the <code>KeyStore</code>.
+     * <code>X509Certificate</code> in the <code>KeyStore</code>.
      * X509Data X509SKI: if the subject key identifier matches an
-     *    <code>X509Certificate</code> in the <code>KeyStore</code>.
+     * <code>X509Certificate</code> in the <code>KeyStore</code>.
      * KeyName: if the keyname matches an alias in the <code>KeyStore</code>.
      * RetrievalMethod: supports rawX509Certificate and X509Data types. If
-     *    rawX509Certificate type, it must match an <code>X509Certificate</code>
-     *    in the <code>KeyStore</code>.
+     * rawX509Certificate type, it must match an <code>X509Certificate</code>
+     * in the <code>KeyStore</code>.
      *
      * @param keyInfo a <code>KeyInfo</code> (may be <code>null</code>)
      * @param purpose the key's purpose
-     * @param method the algorithm method that this key is to be used for.
-     *    Only keys that are compatible with the algorithm and meet the
-     *    constraints of the specified algorithm should be returned.
-     * @param an <code>XMLCryptoContext</code> that may contain additional
-     *    useful information for finding an appropriate key
+     * @param method  the algorithm method that this key is to be used for.
+     *                Only keys that are compatible with the algorithm and meet the
+     *                constraints of the specified algorithm should be returned.
+     * @param context <code>XMLCryptoContext</code> that may contain additional
+     *                useful information for finding an appropriate key
      * @return a key selector result
      * @throws KeySelectorException if an exceptional condition occurs while
-     *    attempting to find a key. Note that an inability to find a key is not
-     *    considered an exception (<code>null</code> should be
-     *    returned in that case). However, an error condition (ex: network
-     *    communications failure) that prevented the <code>KeySelector</code>
-     *    from finding a potential key should be considered an exception.
-     * @throws ClassCastException if the data type of <code>method</code>
-     *    is not supported by this key selector
+     *                              attempting to find a key. Note that an inability to find a key is not
+     *                              considered an exception (<code>null</code> should be
+     *                              returned in that case). However, an error condition (ex: network
+     *                              communications failure) that prevented the <code>KeySelector</code>
+     *                              from finding a potential key should be considered an exception.
+     * @throws ClassCastException   if the data type of <code>method</code>
+     *                              is not supported by this key selector
      */
-    public KeySelectorResult select(KeyInfo keyInfo,
-	KeySelector.Purpose purpose, AlgorithmMethod method,
-	XMLCryptoContext context) throws KeySelectorException {
+    @Override
+    public KeySelectorResult select(final KeyInfo keyInfo,
+                                    final KeySelector.Purpose purpose, final AlgorithmMethod method,
+                                    final XMLCryptoContext context) throws KeySelectorException {
 
-        SignatureMethod sm = (SignatureMethod) method;
+        final SignatureMethod sm = (SignatureMethod) method;
 
         try {
             // return null if keyinfo is null or keystore is empty
@@ -111,56 +112,56 @@ public class X509KeySelector extends KeySelector {
             }
 
             // Iterate through KeyInfo types
-            Iterator i = keyInfo.getContent().iterator();
+            final Iterator i = keyInfo.getContent().iterator();
             while (i.hasNext()) {
-                XMLStructure kiType = (XMLStructure) i.next();
-		// check X509Data
+                final XMLStructure kiType = (XMLStructure) i.next();
+                // check X509Data
                 if (kiType instanceof X509Data) {
-                    X509Data xd = (X509Data) kiType;
-		    KeySelectorResult ksr = x509DataSelect(xd, sm);
-	            if (ksr != null) {
-		        return ksr;
-	            }
-		// check KeyName
+                    final X509Data xd = (X509Data) kiType;
+                    final KeySelectorResult ksr = x509DataSelect(xd, sm);
+                    if (ksr != null) {
+                        return ksr;
+                    }
+                    // check KeyName
                 } else if (kiType instanceof KeyName) {
-		    KeyName kn = (KeyName) kiType;
-		    Certificate cert = ks.getCertificate(kn.getName());
-		    if (cert != null && algEquals(sm.getAlgorithm(),
-			cert.getPublicKey().getAlgorithm())) {
-			return new SimpleKeySelectorResult(cert.getPublicKey());
-		    }
-		// check RetrievalMethod
+                    final KeyName kn = (KeyName) kiType;
+                    final Certificate cert = ks.getCertificate(kn.getName());
+                    if (cert != null && algEquals(sm.getAlgorithm(),
+                            cert.getPublicKey().getAlgorithm())) {
+                        return new SimpleKeySelectorResult(cert.getPublicKey());
+                    }
+                    // check RetrievalMethod
                 } else if (kiType instanceof RetrievalMethod) {
-		    RetrievalMethod rm = (RetrievalMethod) kiType;
+                    final RetrievalMethod rm = (RetrievalMethod) kiType;
                     try {
-			KeySelectorResult ksr = null;
-		        if (rm.getType().equals
-			    (X509Data.RAW_X509_CERTIFICATE_TYPE)) {
-			    OctetStreamData data = (OctetStreamData)
-				rm.dereference(context);
-			    CertificateFactory cf =
-			        CertificateFactory.getInstance("X.509");
-			    X509Certificate cert = (X509Certificate)
-			        cf.generateCertificate(data.getOctetStream());
-		            ksr = certSelect(cert, sm);
-		        } else if (rm.getType().equals(X509Data.TYPE)) {
-			    NodeSetData nd = (NodeSetData)
-				rm.dereference(context);
-			    // convert nd to X509Data
-		            // ksr = x509DataSelect(xd, sm);
-		        } else {
-			    // skip; keyinfo type is not supported
-			    continue;
-			}
-		        if (ksr != null) {
-		            return ksr;
-	                }
-                    } catch (Exception e) {
-		        throw new KeySelectorException(e);
-		    }
-		}
+                        KeySelectorResult ksr = null;
+                        if (rm.getType().equals
+                                (X509Data.RAW_X509_CERTIFICATE_TYPE)) {
+                            final OctetStreamData data = (OctetStreamData)
+                                    rm.dereference(context);
+                            final CertificateFactory cf =
+                                    CertificateFactory.getInstance("X.509");
+                            final X509Certificate cert = (X509Certificate)
+                                    cf.generateCertificate(data.getOctetStream());
+                            ksr = certSelect(cert, sm);
+                        } else if (rm.getType().equals(X509Data.TYPE)) {
+                            final NodeSetData nd = (NodeSetData)
+                                    rm.dereference(context);
+                            // convert nd to X509Data
+                            // ksr = x509DataSelect(xd, sm);
+                        } else {
+                            // skip; keyinfo type is not supported
+                            continue;
+                        }
+                        if (ksr != null) {
+                            return ksr;
+                        }
+                    } catch (final Exception e) {
+                        throw new KeySelectorException(e);
+                    }
+                }
             }
-        } catch (KeyStoreException kse) {
+        } catch (final KeyStoreException kse) {
             // throw exception if keystore is uninitialized
             throw new KeySelectorException(kse);
         }
@@ -174,19 +175,19 @@ public class X509KeySelector extends KeySelector {
      * criteria specified in the CertSelector.
      *
      * @return a KeySelectorResult containing the cert's public key if there
-     *   is a match; otherwise null
+     * is a match; otherwise null
      */
-    private KeySelectorResult keyStoreSelect(CertSelector cs)
-	throws KeyStoreException {
-        Enumeration aliases = ks.aliases();
+    private KeySelectorResult keyStoreSelect(final CertSelector cs)
+            throws KeyStoreException {
+        final Enumeration aliases = ks.aliases();
         while (aliases.hasMoreElements()) {
-	    String alias = (String) aliases.nextElement();
-	    Certificate cert = ks.getCertificate(alias);
-	    if (cert != null && cs.match(cert)) {
-	        return new SimpleKeySelectorResult(cert.getPublicKey());
-	    }
-	}
-	return null;
+            final String alias = (String) aliases.nextElement();
+            final Certificate cert = ks.getCertificate(alias);
+            if (cert != null && cs.match(cert)) {
+                return new SimpleKeySelectorResult(cert.getPublicKey());
+            }
+        }
+        return null;
     }
 
     /**
@@ -195,47 +196,54 @@ public class X509KeySelector extends KeySelector {
      * with the specified SignatureMethod.
      *
      * @return a KeySelectorResult containing the cert's public key if there
-     *   is a match; otherwise null
+     * is a match; otherwise null
      */
-    private KeySelectorResult certSelect(X509Certificate xcert,
-	SignatureMethod sm) throws KeyStoreException {
+    private KeySelectorResult certSelect(final X509Certificate xcert,
+                                         final SignatureMethod sm) throws KeyStoreException {
         // skip non-signer certs
-        boolean[] keyUsage = xcert.getKeyUsage();
+        final boolean[] keyUsage = xcert.getKeyUsage();
         if (keyUsage[0] == false) {
             return null;
         }
-        String alias = ks.getCertificateAlias(xcert);
+        final String alias = ks.getCertificateAlias(xcert);
         if (alias != null) {
-            PublicKey pk = ks.getCertificate(alias).getPublicKey();
+            final PublicKey pk = ks.getCertificate(alias).getPublicKey();
             // make sure algorithm is compatible with method
             if (algEquals(sm.getAlgorithm(), pk.getAlgorithm())) {
                 return new SimpleKeySelectorResult(pk);
             }
         }
-	return null;
+        return null;
     }
 
     /**
      * Returns an OID of a public-key algorithm compatible with the specified
      * signature algorithm URI.
      */
-    private String getPKAlgorithmOID(String algURI) {
-	if (algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
-	    return "1.2.840.10040.4.1";
-	} else if (algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
-	    return "1.2.840.113549.1.1";
-	} else {
-	    return null;
-	}
+    private String getPKAlgorithmOID(final String algURI) {
+        if (algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
+            return "1.2.840.10040.4.1";
+        } else if (algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
+            return "1.2.840.113549.1.1";
+        } else {
+            return null;
+        }
     }
 
     /**
      * A simple KeySelectorResult containing a public key.
      */
     private static class SimpleKeySelectorResult implements KeySelectorResult {
-	private final Key key;
-	SimpleKeySelectorResult(Key key) { this.key = key; }
-	public Key getKey() { return key; }
+        private final Key key;
+
+        SimpleKeySelectorResult(final Key key) {
+            this.key = key;
+        }
+
+        @Override
+        public Key getKey() {
+            return key;
+        }
     }
 
     /**
@@ -243,12 +251,12 @@ public class X509KeySelector extends KeySelector {
      * the specified signature algorithm URI.
      */
     //@@@FIXME: this should also work for key types other than DSA/RSA
-    private boolean algEquals(String algURI, String algName) {
+    private boolean algEquals(final String algURI, final String algName) {
         if (algName.equalsIgnoreCase("DSA") &&
-            algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
+                algURI.equalsIgnoreCase(SignatureMethod.DSA_SHA1)) {
             return true;
         } else if (algName.equalsIgnoreCase("RSA") &&
-            algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
+                algURI.equalsIgnoreCase(SignatureMethod.RSA_SHA1)) {
             return true;
         } else {
             return false;
@@ -261,77 +269,77 @@ public class X509KeySelector extends KeySelector {
      * compatible with the specified SignatureMethod.
      *
      * @return a KeySelectorResult containing the cert's public key if there
-     *   is a match; otherwise null
+     * is a match; otherwise null
      */
-    private KeySelectorResult x509DataSelect(X509Data xd, SignatureMethod sm)
-	throws KeyStoreException, KeySelectorException {
+    private KeySelectorResult x509DataSelect(final X509Data xd, final SignatureMethod sm)
+            throws KeyStoreException, KeySelectorException {
 
-	// convert signature algorithm to compatible public-key alg OID
-	String algOID = getPKAlgorithmOID(sm.getAlgorithm());
+        // convert signature algorithm to compatible public-key alg OID
+        final String algOID = getPKAlgorithmOID(sm.getAlgorithm());
 
-	KeySelectorResult ksr = null;
-        Iterator xi = xd.getContent().iterator();
+        KeySelectorResult ksr = null;
+        final Iterator xi = xd.getContent().iterator();
         while (xi.hasNext()) {
-	    ksr = null;
-            Object o = xi.next();
-	    // check X509Certificate
+            ksr = null;
+            final Object o = xi.next();
+            // check X509Certificate
             if (o instanceof X509Certificate) {
-                X509Certificate xcert = (X509Certificate) o;
-	        ksr = certSelect(xcert, sm);
-	    // check X509IssuerSerial
-	    } else if (o instanceof X509IssuerSerial) {
-	        X509IssuerSerial xis = (X509IssuerSerial) o;
-	        X509CertSelector xcs = new X509CertSelector();
-	        try {
-	            xcs.setSubjectPublicKeyAlgID(algOID);
-	            xcs.setSerialNumber(xis.getSerialNumber());
-		    xcs.setIssuer(new X500Principal
-		        (xis.getIssuerName()).getName());
-	        } catch (IOException ioe) {
-		    throw new KeySelectorException(ioe);
-		}
-		ksr = keyStoreSelect(xcs);
-	    // check X509SubjectName
-	    } else if (o instanceof String) {
-	        String sn = (String) o;
-	        X509CertSelector xcs = new X509CertSelector();
-	        try {
-	            xcs.setSubjectPublicKeyAlgID(algOID);
-		    xcs.setSubject(new X500Principal(sn).getName());
-		} catch (IOException ioe) {
-		    throw new KeySelectorException(ioe);
-		}
-		ksr = keyStoreSelect(xcs);
-	    // check X509SKI
-	    } else if (o instanceof byte[]) {
-	        byte[] ski = (byte[]) o;
-	        X509CertSelector xcs = new X509CertSelector();
-	        try {
-	            xcs.setSubjectPublicKeyAlgID(algOID);
-		} catch (IOException ioe) {
-		    throw new KeySelectorException(ioe);
-		}
-		// DER-encode ski - required by X509CertSelector
-		byte[] encodedSki = new byte[ski.length+2];
-		encodedSki[0] = 0x04; // OCTET STRING tag value
-		encodedSki[1] = (byte) ski.length; // length
-		System.arraycopy(ski, 0, encodedSki, 2, ski.length);
-		xcs.setSubjectKeyIdentifier(encodedSki);
-		ksr = keyStoreSelect(xcs);
-	    // check X509CRL
-	    // not supported: should use CertPath API
-	    } else {
-	        // skip all other entries
-	        continue;
-	    }
-	    if (ksr != null) {
-		return ksr;
-	    }
-	}
-	return null;
+                final X509Certificate xcert = (X509Certificate) o;
+                ksr = certSelect(xcert, sm);
+                // check X509IssuerSerial
+            } else if (o instanceof X509IssuerSerial) {
+                final X509IssuerSerial xis = (X509IssuerSerial) o;
+                final X509CertSelector xcs = new X509CertSelector();
+                try {
+                    xcs.setSubjectPublicKeyAlgID(algOID);
+                    xcs.setSerialNumber(xis.getSerialNumber());
+                    xcs.setIssuer(new X500Principal
+                            (xis.getIssuerName()).getName());
+                } catch (final IOException ioe) {
+                    throw new KeySelectorException(ioe);
+                }
+                ksr = keyStoreSelect(xcs);
+                // check X509SubjectName
+            } else if (o instanceof String) {
+                final String sn = (String) o;
+                final X509CertSelector xcs = new X509CertSelector();
+                try {
+                    xcs.setSubjectPublicKeyAlgID(algOID);
+                    xcs.setSubject(new X500Principal(sn).getName());
+                } catch (final IOException ioe) {
+                    throw new KeySelectorException(ioe);
+                }
+                ksr = keyStoreSelect(xcs);
+                // check X509SKI
+            } else if (o instanceof byte[]) {
+                final byte[] ski = (byte[]) o;
+                final X509CertSelector xcs = new X509CertSelector();
+                try {
+                    xcs.setSubjectPublicKeyAlgID(algOID);
+                } catch (final IOException ioe) {
+                    throw new KeySelectorException(ioe);
+                }
+                // DER-encode ski - required by X509CertSelector
+                final byte[] encodedSki = new byte[ski.length + 2];
+                encodedSki[0] = 0x04; // OCTET STRING tag value
+                encodedSki[1] = (byte) ski.length; // length
+                System.arraycopy(ski, 0, encodedSki, 2, ski.length);
+                xcs.setSubjectKeyIdentifier(encodedSki);
+                ksr = keyStoreSelect(xcs);
+                // check X509CRL
+                // not supported: should use CertPath API
+            } else {
+                // skip all other entries
+                continue;
+            }
+            if (ksr != null) {
+                return ksr;
+            }
+        }
+        return null;
     }
 
-    public static void main( String[] args ) throws Exception {
+    public static void main(final String[] args) throws Exception {
 
     }
 }

--- a/src/main/java/ro/kuberam/libs/java/crypto/toDo/X509KeySelector.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/toDo/X509KeySelector.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.toDo;
 
 import java.io.InputStream;

--- a/src/main/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexString.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexString.java
@@ -1,13 +1,13 @@
 package ro.kuberam.libs.java.crypto.utils;
 
 public class ByteArray2HexString {
-	
-	public String convert(byte[] byteArray) {
-		 StringBuffer sb = new StringBuffer();
-		 for (int i = 0; i < byteArray.length; ++i) {
-		 sb.append(Integer.toHexString((byteArray[i] & 0xFF) | 0x100).substring(1,3));
-		 }
-		 return sb.toString();
-	}
+
+    public String convert(final byte[] byteArray) {
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < byteArray.length; ++i) {
+            sb.append(Integer.toHexString((byteArray[i] & 0xFF) | 0x100).substring(1, 3));
+        }
+        return sb.toString();
+    }
 }
 //TODO: make this work with large byte arrays, maybe with a pipeline 

--- a/src/main/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexString.java
+++ b/src/main/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexString.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.utils;
 
 public class ByteArray2HexString {

--- a/src/test/java/ro/kuberam/libs/java/crypto/CryptoModuleTests.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/CryptoModuleTests.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 import java.io.*;

--- a/src/test/java/ro/kuberam/libs/java/crypto/CryptoModuleTests.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/CryptoModuleTests.java
@@ -1,15 +1,10 @@
 package ro.kuberam.libs.java.crypto;
 
-import java.io.ByteArrayOutputStream;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.ObjectOutputStream;
-import java.io.PipedInputStream;
-import java.io.PipedOutputStream;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.util.UUID;
@@ -25,172 +20,158 @@ import ro.kuberam.tests.junit.BaseTest;
 
 public class CryptoModuleTests extends BaseTest {
 
-	@Test
-	public void pipedStreams1Test() throws Exception {
-		final String message = "String for tests.";
+    @Test
+    public void pipedStreams1Test() throws Exception {
+        final String message = "String for tests.";
 
-		PipedInputStream in = new PipedInputStream();
-		final PipedOutputStream outp = new PipedOutputStream(in);
-		new Thread(new Runnable() {
-			public void run() {
-				try {
-					outp.write(message.getBytes(StandardCharsets.UTF_8));
-				} catch (IOException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-			}
-		}).start();
+        try (final PipedInputStream in = new PipedInputStream();
+             final PipedOutputStream outp = new PipedOutputStream(in)) {
+            new Thread(() -> {
+                try {
+                    outp.write(message.getBytes(StandardCharsets.UTF_8));
+                } catch (final IOException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
+            }).start();
 
-		System.out.println("result: " + in);
-	}
+            System.out.println("result: " + in);
+        }
+    }
 
-	@Ignore
-	@Test
-	public void pipedStreams2Test() throws Exception {
-		InputStream document = getClass().getResourceAsStream("../doc-1.xml");
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		int next = document.read();
-		while (next > -1) {
-			bos.write(next);
-			next = document.read();
-		}
-		bos.flush();
-		byte[] result = bos.toByteArray();
+    @Ignore
+    @Test
+    public void pipedStreams2Test() throws Exception {
+        try (final InputStream document = getClass().getResourceAsStream("../doc-1.xml");
+             final ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            int next = document.read();
+            while (next > -1) {
+                bos.write(next);
+                next = document.read();
+            }
+            bos.flush();
+            final byte[] result = bos.toByteArray();
 
-		PipedOutputStream poStream = new PipedOutputStream();
-		PipedInputStream piStream = new PipedInputStream();
+            try (final PipedOutputStream poStream = new PipedOutputStream();
+                 final PipedInputStream piStream = new PipedInputStream()) {
 
-		// piped input stream connect to the piped output stream
-		piStream.connect(poStream);
+                // piped input stream connect to the piped output stream
+                piStream.connect(poStream);
 
-		// Writes specified byte array.
-		poStream.write(result);
+                // Writes specified byte array.
+                poStream.write(result);
 
-		// Reads the next byte of data from this piped input stream.
-		for (int i = 0; i < result.length; i++) {
-			System.out.println(piStream.read());
-		}
+                // Reads the next byte of data from this piped input stream.
+                for (int i = 0; i < result.length; i++) {
+                    System.out.println(piStream.read());
+                }
+            }
+        }
+    }
 
-		// Closes piped input stream
-		poStream.close();
+    @Test
+    public void digestOutputStreamTest() throws Exception {
+        final MessageDigest md = MessageDigest.getInstance("SHA-512");
 
-		// Closes piped output stream
-		piStream.close();
-	}
+        try (final OutputStream fos = Files.newOutputStream(Paths.get("/home/claudius/workspace-claudius/expath-crypto/src/org/expath/crypto/tests/string.txt"));
+             final DigestOutputStream dos = new DigestOutputStream(fos, md);
+             final ObjectOutputStream oos = new ObjectOutputStream(dos)
+        ) {
 
-	@Test
-	public void digestOutputStreamTest() throws Exception {
-		try {
-			FileOutputStream fos = new FileOutputStream(
-					"/home/claudius/workspace-claudius/expath-crypto/src/org/expath/crypto/tests/string.txt");
-			MessageDigest md = MessageDigest.getInstance("SHA-512");
-			DigestOutputStream dos = new DigestOutputStream(fos, md);
-			ObjectOutputStream oos = new ObjectOutputStream(dos);
-			String data = "This have I thought good to deliver thee, "
-					+ "that thou mightst not lose the dues of rejoicing "
-					+ "by being ignorant of what greatness is promised thee.";
-			oos.writeObject(data);
-			dos.on(false);
-			byte[] digest = md.digest();
-			oos.writeObject(digest);
-			int digestLength = digest.length;
-			System.out.println("length: " + digestLength);
-			BigInteger bi = new BigInteger(1, digest);
-			String result = bi.toString(digestLength);
-			if (result.length() % 2 != 0) {
-				result = "0" + result;
-			}
+            final String data = "This have I thought good to deliver thee, "
+                    + "that thou mightst not lose the dues of rejoicing "
+                    + "by being ignorant of what greatness is promised thee.";
+            oos.writeObject(data);
+            dos.on(false);
+            final byte[] digest = md.digest();
+            oos.writeObject(digest);
+            final int digestLength = digest.length;
+            System.out.println("length: " + digestLength);
+            final BigInteger bi = new BigInteger(1, digest);
+            String result = bi.toString(digestLength);
+            if (result.length() % 2 != 0) {
+                result = "0" + result;
+            }
 
-			System.out.println("result: " + result);
-		} catch (Exception e) {
-			System.out.println(e);
-		}
-	}
+            System.out.println("result: " + result);
+        }
+    }
 
-	public InputStream openStream() throws IOException {
-		final PipedOutputStream out = new PipedOutputStream();
-		PipedInputStream in = new PipedInputStream(out);
+    public InputStream openStream() throws IOException {
+        final PipedOutputStream out = new PipedOutputStream();
+        final PipedInputStream in = new PipedInputStream(out);
 
-		Runnable exporter = new Runnable() {
-			public void run() {
-				try {
-					out.write("message".getBytes(StandardCharsets.UTF_8));
-				} catch (UnsupportedEncodingException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				} catch (IOException e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
-				IOUtils.closeQuietly(out);
-			}
-		};
+        final Runnable exporter = () -> {
+            try {
+                out.write("message".getBytes(StandardCharsets.UTF_8));
+            } catch (IOException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+            IOUtils.closeQuietly(out);
+        };
 
-		// executor.submit(exporter);
+        // executor.submit(exporter);
 
-		return in;
-	}
+        return in;
+    }
 
-	@Test
-	public void uuid5Test() throws Exception {
+    @Test
+    public void uuid5Test() throws Exception {
+        final String seed = "www.widgets.com";
 
-		String seed = "www.widgets.com";
+        final NameBasedGenerator uuid_gen_dns = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_DNS);
+        final UUID uuid_dns = uuid_gen_dns.generate(seed);
+        System.out.println("uuid_dns: " + uuid_dns);
 
-		NameBasedGenerator uuid_gen_dns = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_DNS);
-		UUID uuid_dns = uuid_gen_dns.generate(seed);
-		System.out.println("uuid_dns: " + uuid_dns);
+        final NameBasedGenerator uuid_gen_oid = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_OID);
+        final UUID uuid_oid = uuid_gen_oid.generate(seed);
+        System.out.println("uuid_oid: " + uuid_oid);
 
-		NameBasedGenerator uuid_gen_oid = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_OID);
-		UUID uuid_oid = uuid_gen_oid.generate(seed);
-		System.out.println("uuid_oid: " + uuid_oid);
+        final NameBasedGenerator uuid_gen_url = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_URL);
+        final UUID uuid_url = uuid_gen_url.generate(seed);
+        System.out.println("uuid_url: " + uuid_url);
 
-		NameBasedGenerator uuid_gen_url = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_URL);
-		UUID uuid_url = uuid_gen_url.generate(seed);
-		System.out.println("uuid_url: " + uuid_url);
+        final NameBasedGenerator uuid_gen_x500 = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_X500);
+        final UUID uuid_x500 = uuid_gen_x500.generate(seed);
+        System.out.println("uuid_x500: " + uuid_x500);
+    }
 
-		NameBasedGenerator uuid_gen_x500 = Generators.nameBasedGenerator(NameBasedGenerator.NAMESPACE_X500);
-		UUID uuid_x500 = uuid_gen_x500.generate(seed);
-		System.out.println("uuid_x500: " + uuid_x500);
+    @Test
+    public void uuid5NewTest() throws Exception {
+        final String NameSpace_OID_string = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
+        final UUID NameSpace_OID_uuid = UUID.fromString(NameSpace_OID_string);
 
-	}
+        final long msb = NameSpace_OID_uuid.getMostSignificantBits();
+        final long lsb = NameSpace_OID_uuid.getLeastSignificantBits();
 
-	@Test
-	public void uuid5NewTest() throws Exception {
-		String NameSpace_OID_string = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
-		UUID NameSpace_OID_uuid = UUID.fromString(NameSpace_OID_string);
+        final byte[] NameSpace_OID_buffer = new byte[16];
 
-		long msb = NameSpace_OID_uuid.getMostSignificantBits();
-		long lsb = NameSpace_OID_uuid.getLeastSignificantBits();
+        for (int i = 0; i < 8; i++) {
+            NameSpace_OID_buffer[i] = (byte) (msb >>> 8 * (7 - i));
+        }
+        for (int i = 8; i < 16; i++) {
+            NameSpace_OID_buffer[i] = (byte) (lsb >>> 8 * (7 - i));
+        }
 
-		byte[] NameSpace_OID_buffer = new byte[16];
+        final String name = "user123";
+        final byte[] name_buffer = name.getBytes();
 
-		for (int i = 0; i < 8; i++) {
-			NameSpace_OID_buffer[i] = (byte) (msb >>> 8 * (7 - i));
-		}
-		for (int i = 8; i < 16; i++) {
-			NameSpace_OID_buffer[i] = (byte) (lsb >>> 8 * (7 - i));
-		}
 
-		String name = "user123";
-		byte[] name_buffer = name.getBytes();
+        try (final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            outputStream.write(NameSpace_OID_buffer);
+            outputStream.write(name_buffer);
 
-		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		try {
-			outputStream.write(NameSpace_OID_buffer);
-			outputStream.write(name_buffer);
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+            final byte byteArray[] = outputStream.toByteArray();
+            System.out.println(UUID.nameUUIDFromBytes(byteArray).toString());
+        } catch (final IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
 
-		byte byteArray[] = outputStream.toByteArray();
+    public static void main(final String[] args) throws Exception {
 
-		System.out.println(UUID.nameUUIDFromBytes(byteArray).toString());
-	}
-
-	public static void main(String[] args) throws Exception {
-
-	}
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/ParametersTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/ParametersTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/ParametersTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/ParametersTest.java
@@ -1,73 +1,73 @@
 package ro.kuberam.libs.java.crypto;
 
-import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ParametersTest {
 
-	@Test
-	public void testCanonicalizationAlgorithmWrongValue() {
-		Parameters parameters = new Parameters();
+    @Test
+    public void testCanonicalizationAlgorithmWrongValue() {
+        final Parameters parameters = new Parameters();
 
-		try {
-			parameters.setCanonicalizationAlgorithm("inclusive-with-commentss");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
-		}
-	}
+        try {
+            parameters.setCanonicalizationAlgorithm("inclusive-with-commentss");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
+        }
+    }
 
-	@Test
-	public void testCanonicalizationAlgorithmDefaultValue() {
-		Parameters parameters = new Parameters();
+    @Test
+    public void testCanonicalizationAlgorithmDefaultValue() {
+        final Parameters parameters = new Parameters();
+        assertEquals("http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments", parameters.getCanonicalizationAlgorithm());
+    }
 
-		Assert.assertTrue(parameters.getCanonicalizationAlgorithm().equals(
-				"http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments"));
-	}
+    @Test
+    public void testDigestAlgorithmWrongValue() {
+        final Parameters parameters = new Parameters();
 
-	@Test
-	public void testDigestAlgorithmWrongValue() {
-		Parameters parameters = new Parameters();
+        try {
+            parameters.setDigestAlgorithm("SHA1008");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
+        }
+    }
 
-		try {
-			parameters.setDigestAlgorithm("SHA1008");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
-		}
-	}
+    @Test
+    public void testDigestAlgorithmDefaultValue() {
+        final Parameters parameters = new Parameters();
 
-	@Test
-	public void testDigestAlgorithmDefaultValue() {
-		Parameters parameters = new Parameters();
+        assertEquals("http://www.w3.org/2000/09/xmldsig#sha1", parameters.getDigestAlgorithm());
+    }
 
-		Assert.assertTrue(parameters.getDigestAlgorithm().equals("http://www.w3.org/2000/09/xmldsig#sha1"));
-	}
+    @Test
+    public void testSignatureAlgorithmWrongValue() {
+        final Parameters parameters = new Parameters();
 
-	@Test
-	public void testSignatureAlgorithmWrongValue() {
-		Parameters parameters = new Parameters();
+        try {
+            parameters.setSignatureAlgorithm("RSA_SHA1008");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
+        }
+    }
 
-		try {
-			parameters.setSignatureAlgorithm("RSA_SHA1008");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().contains(ErrorMessages.error_unknownAlgorithm));
-		}
-	}
+    @Test
+    public void testSignatureAlgorithmDefaultValue() {
+        final Parameters parameters = new Parameters();
+        System.out.println(parameters.getSignatureAlgorithm());
+        assertEquals("http://www.w3.org/2000/09/xmldsig#rsa-sha1", parameters.getSignatureAlgorithm());
+    }
 
-	@Test
-	public void testSignatureAlgorithmDefaultValue() {
-		Parameters parameters = new Parameters();
-		System.out.println(parameters.getSignatureAlgorithm());
-		Assert.assertTrue(parameters.getSignatureAlgorithm().equals("http://www.w3.org/2000/09/xmldsig#rsa-sha1"));
-	}
+    @Test
+    public void testSignatureNamespacePrefixDefaultValue() {
+        final Parameters parameters = new Parameters();
 
-	@Test
-	public void testSignatureNamespacePrefixDefaultValue() {
-		Parameters parameters = new Parameters();
-
-		Assert.assertTrue(parameters.getSignatureNamespacePrefix().equals("dsig"));
-	}
+        assertEquals("dsig", parameters.getSignatureNamespacePrefix());
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/PipedIOApp.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/PipedIOApp.java
@@ -5,83 +5,87 @@ import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 
 public class PipedIOApp {
-	public static void main(String args[]) {
-		Thread thread1 = new Thread(new PipeOutput("Producer"));
-		Thread thread2 = new Thread(new PipeInput("Consumer"));
-		thread1.start();
-		thread2.start();
-		boolean thread1IsAlive = true;
-		boolean thread2IsAlive = true;
-		do {
-			if (thread1IsAlive && !thread1.isAlive()) {
-				thread1IsAlive = false;
-			}
-			if (thread2IsAlive && !thread2.isAlive()) {
-				thread2IsAlive = false;
-			}
-		} while (thread1IsAlive || thread2IsAlive);
-	}
+    public static void main(final String args[]) {
+        final Thread thread1 = new Thread(new PipeOutput("Producer"));
+        final Thread thread2 = new Thread(new PipeInput("Consumer"));
+        thread1.start();
+        thread2.start();
+        boolean thread1IsAlive = true;
+        boolean thread2IsAlive = true;
+        do {
+            if (thread1IsAlive && !thread1.isAlive()) {
+                thread1IsAlive = false;
+            }
+            if (thread2IsAlive && !thread2.isAlive()) {
+                thread2IsAlive = false;
+            }
+        } while (thread1IsAlive || thread2IsAlive);
+    }
 }
 
 class PipeIO {
-	static PipedOutputStream outputPipe = new PipedOutputStream();
+    static final PipedOutputStream outputPipe = new PipedOutputStream();
 
-	static PipedInputStream inputPipe = new PipedInputStream();
-	static {
-		try {
-			outputPipe.connect(inputPipe);
-		} catch (IOException ex) {
-			System.out.println("IOException in static initializer");
-		}
-	}
+    static final PipedInputStream inputPipe = new PipedInputStream();
 
-	String name;
+    static {
+        try {
+            outputPipe.connect(inputPipe);
+        } catch (final IOException ex) {
+            System.out.println("IOException in static initializer");
+        }
+    }
 
-	public PipeIO(String id) {
-		name = id;
-	}
+    String name;
+
+    public PipeIO(final String id) {
+        name = id;
+    }
 }
 
 class PipeOutput extends PipeIO implements Runnable {
-	public PipeOutput(String id) {
-		super(id);
-	}
+    public PipeOutput(final String id) {
+        super(id);
+    }
 
-	public void run() {
-		String s = "This is a test.";
-		try {
-			for (int i = 0; i < s.length(); ++i) {
-				outputPipe.write(s.charAt(i));
-				System.out.println(name + " wrote " + s.charAt(i));
-			}
-			outputPipe.write('!');
-		} catch (IOException ex) {
-			System.out.println("IOException in PipeOutput");
-		}
-	}
+    @Override
+    public void run() {
+        final String s = "This is a test.";
+        try {
+            for (int i = 0; i < s.length(); ++i) {
+                outputPipe.write(s.charAt(i));
+                System.out.println(name + " wrote " + s.charAt(i));
+            }
+            outputPipe.write('!');
+        } catch (final IOException ex) {
+            System.out.println("IOException in PipeOutput");
+        }
+    }
 }
 
 class PipeInput extends PipeIO implements Runnable {
-	public PipeInput(String id) {
-		super(id);
-	}
+    public PipeInput(final String id) {
+        super(id);
+    }
 
-	public void run() {
-		boolean eof = false;
-		try {
-			while (!eof) {
-				int inChar = inputPipe.read();
-				if (inChar != -1) {
-					char ch = (char) inChar;
-					if (ch == '!') {
-						eof = true;
-						break;
-					} else
-						System.out.println(name + " read " + ch);
-				}
-			}
-		} catch (IOException ex) {
-			System.out.println("IOException in PipeOutput");
-		}
-	}
+    @Override
+    public void run() {
+        boolean eof = false;
+        try {
+            while (!eof) {
+                final int inChar = inputPipe.read();
+                if (inChar != -1) {
+                    char ch = (char) inChar;
+                    if (ch == '!') {
+                        eof = true;
+                        break;
+                    } else {
+                        System.out.println(name + " read " + ch);
+                    }
+                }
+            }
+        } catch (final IOException ex) {
+            System.out.println("IOException in PipeOutput");
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/PipedIOApp.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/PipedIOApp.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 import java.io.IOException;

--- a/src/test/java/ro/kuberam/libs/java/crypto/PipedInputStreamExample.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/PipedInputStreamExample.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto;
 
 import java.io.DataInputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/PipedInputStreamExample.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/PipedInputStreamExample.java
@@ -6,32 +6,31 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+
 /**
-* Java PipedInputStream example
-* shows how to read bytes in one Java thread
-* sent by PipedOutputStream object from another Java thread
-*/
+ * Java PipedInputStream example
+ * shows how to read bytes in one Java thread
+ * sent by PipedOutputStream object from another Java thread
+ */
 
 /*
  * Receiver thread class - reads bytes from the stream
  */
 class ReceiverThread extends Thread {
-    private DataInputStream in;
-   
-    public ReceiverThread(InputStream is) {
+    private final DataInputStream in;
+
+    public ReceiverThread(final InputStream is) {
         in = new DataInputStream(is);
     }
-   
+
     @Override
     public void run() {
         //Reading data from the stream
-         try
-       {
-             System.out.println(in.readDouble() + " " + in.readChar() + " " + in.readInt());
-         }
-         catch (Exception e) {
-             e.printStackTrace();
-       }
+        try {
+            System.out.println(in.readDouble() + " " + in.readChar() + " " + in.readInt());
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
     }
 }
 
@@ -39,42 +38,40 @@ class ReceiverThread extends Thread {
  * Producer thread class - sends bytes data to the stream
  */
 class SenderThread extends Thread {
-    private DataOutputStream out;
-   
-    public SenderThread(OutputStream os) {
+    private final DataOutputStream out;
+
+    public SenderThread(final OutputStream os) {
         out = new DataOutputStream(os);
     }
-   
+
     @Override
     public void run() {
         //Writing data to the stream
-         try
-       {
-             out.writeDouble(123.45);
-             out.writeChar('c');
-             out.writeInt(67);
-         }
-         catch (Exception e) {
-             e.printStackTrace();
-       }
+        try {
+            out.writeDouble(123.45);
+            out.writeChar('c');
+            out.writeInt(67);
+        } catch (final Exception e) {
+            e.printStackTrace();
+        }
     }
-   
+
 }
 
 public class PipedInputStreamExample {
-       
-    public static void main(String[] args) throws Exception {
-        PipedOutputStream pos = new PipedOutputStream();
-        PipedInputStream pis = new PipedInputStream(pos);
-        SenderThread senderThread = new SenderThread(pos);
-        ReceiverThread receiverThread = new ReceiverThread(pis);
-        senderThread.start();  //send data to the piped stream
-        receiverThread.start();//read data from the same piped stream
-       
-        //wait for all threads to finish
-        senderThread.join();
-        receiverThread.join();
-        pis.close();
-        pos.close();
+
+    public static void main(final String[] args) throws Exception {
+        try (final PipedOutputStream pos = new PipedOutputStream();
+             final PipedInputStream pis = new PipedInputStream(pos)) {
+
+            final SenderThread senderThread = new SenderThread(pos);
+            final ReceiverThread receiverThread = new ReceiverThread(pis);
+            senderThread.start();  //send data to the piped stream
+            receiverThread.start();//read data from the same piped stream
+
+            //wait for all threads to finish
+            senderThread.join();
+            receiverThread.join();
+        }
     }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/GenerateAWSsignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/GenerateAWSsignature.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/GenerateAWSsignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/GenerateAWSsignature.java
@@ -5,46 +5,47 @@ import java.util.Arrays;
 
 import javax.xml.bind.DatatypeConverter;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class GenerateAWSsignature extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha256() throws Exception {
-		String key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
-		String dateStamp = "20120215";
-		String regionName = "us-east-1";
-		String serviceName = "iam";
+    @Test
+    public void hmacStringWithSha256() throws Exception {
+        final String key = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+        final String dateStamp = "20120215";
+        final String regionName = "us-east-1";
+        final String serviceName = "iam";
 
-		String kSecret = "AWS4" + key;
-		String kSecretHexValue = DatatypeConverter.printHexBinary(kSecret.getBytes(StandardCharsets.UTF_8))
-				.toLowerCase();
-		Assert.assertTrue(kSecretHexValue
-				.equals("41575334774a616c725855746e46454d492f4b374d44454e472b62507852666943594558414d504c454b4559"));
+        final String kSecret = "AWS4" + key;
+        final String kSecretHexValue = DatatypeConverter.printHexBinary(kSecret.getBytes(StandardCharsets.UTF_8))
+                .toLowerCase();
+        assertTrue(kSecretHexValue
+                .equals("41575334774a616c725855746e46454d492f4b374d44454e472b62507852666943594558414d504c454b4559"));
 
-		byte[] kDate = Hmac.hmac(dateStamp.getBytes(StandardCharsets.UTF_8), kSecret.getBytes(StandardCharsets.UTF_8),
-				"HMAC-SHA-256");
-		System.out.println(Arrays.toString(kDate));
-		String kDateHexValue = generateHexValue(kDate);
-		Assert.assertTrue(kDateHexValue.equals("969fbb94feb542b71ede6f87fe4d5fa29c789342b0f407474670f0c2489e0a0d"));
+        final byte[] kDate = Hmac.hmac(dateStamp.getBytes(StandardCharsets.UTF_8), kSecret.getBytes(StandardCharsets.UTF_8),
+                "HMAC-SHA-256");
+        System.out.println(Arrays.toString(kDate));
+        final String kDateHexValue = generateHexValue(kDate);
+        assertTrue(kDateHexValue.equals("969fbb94feb542b71ede6f87fe4d5fa29c789342b0f407474670f0c2489e0a0d"));
 
-		byte[] kRegion = Hmac.hmac(regionName.getBytes(StandardCharsets.UTF_8), kDate, "HMAC-SHA-256");
-		String kRegionHexValue = generateHexValue(kRegion);
-		Assert.assertTrue(kRegionHexValue.equals("69daa0209cd9c5ff5c8ced464a696fd4252e981430b10e3d3fd8e2f197d7a70c"));
+        final byte[] kRegion = Hmac.hmac(regionName.getBytes(StandardCharsets.UTF_8), kDate, "HMAC-SHA-256");
+        String kRegionHexValue = generateHexValue(kRegion);
+        assertTrue(kRegionHexValue.equals("69daa0209cd9c5ff5c8ced464a696fd4252e981430b10e3d3fd8e2f197d7a70c"));
 
-		byte[] kService = Hmac.hmac(serviceName.getBytes(StandardCharsets.UTF_8), kRegion, "HMAC-SHA-256");
-		String kServiceHexValue = generateHexValue(kService);
-		Assert.assertTrue(kServiceHexValue.equals("f72cfd46f26bc4643f06a11eabb6c0ba18780c19a8da0c31ace671265e3c87fa"));
+        final byte[] kService = Hmac.hmac(serviceName.getBytes(StandardCharsets.UTF_8), kRegion, "HMAC-SHA-256");
+        String kServiceHexValue = generateHexValue(kService);
+        assertTrue(kServiceHexValue.equals("f72cfd46f26bc4643f06a11eabb6c0ba18780c19a8da0c31ace671265e3c87fa"));
 
-		byte[] kSigning = Hmac.hmac("aws4_request".getBytes(StandardCharsets.UTF_8), kService, "HMAC-SHA-256");
-		String kSigningHexValue = generateHexValue(kSigning);
-		Assert.assertTrue(kSigningHexValue.equals("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"));
-	}
+        final byte[] kSigning = Hmac.hmac("aws4_request".getBytes(StandardCharsets.UTF_8), kService, "HMAC-SHA-256");
+        String kSigningHexValue = generateHexValue(kSigning);
+        assertTrue(kSigningHexValue.equals("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"));
+    }
 
-	private String generateHexValue(byte[] hexValue) {
-		return DatatypeConverter.printHexBinary(hexValue).toLowerCase();
-	}
+    private String generateHexValue(byte[] hexValue) {
+        return DatatypeConverter.printHexBinary(hexValue).toLowerCase();
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithMd5 extends BaseTest {
 
-	@Test
-	public void hashBinaryWithMd5() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "MD5", "base64");
-
-		Assert.assertTrue(result.equals("UI/aOJodA6gtJPitQ6xcJA=="));
-	}
+    @Test
+    public void hashBinaryWithMd5() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "MD5", "base64");
+            assertTrue(result.equals("UI/aOJodA6gtJPitQ6xcJA=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithMd5AndDefaultFormat.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithMd5AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithMd5() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "MD5");
-
-		Assert.assertTrue(result.equals("UI/aOJodA6gtJPitQ6xcJA=="));
-	}
+    @Test
+    public void hashBinaryWithMd5() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "MD5");
+            assertTrue(result.equals("UI/aOJodA6gtJPitQ6xcJA=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithSha1 extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha1() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-1", "base64");
-
-		Assert.assertTrue(result.equals("GyscHvnJKxInsBLgSg/FRAmQXYU="));
-	}
+    @Test
+    public void hashBinaryWithSha1() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-1", "base64");
+            assertTrue(result.equals("GyscHvnJKxInsBLgSg/FRAmQXYU="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1AndDefaultFormat.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithSha1AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha1() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-1");
-
-		Assert.assertTrue(result.equals("GyscHvnJKxInsBLgSg/FRAmQXYU="));
-	}
+    @Test
+    public void hashBinaryWithSha1() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-1");
+            assertTrue(result.equals("GyscHvnJKxInsBLgSg/FRAmQXYU="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha1AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithSha256 extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha256() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-256", "base64");
-
-		Assert.assertTrue(result.equals("37JiNBym250ye3aUJ04RaZg3SFSP03qJ8FR/I1JckVI="));
-	}
+    @Test
+    public void hashBinaryWithSha256() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-256", "base64");
+            assertTrue(result.equals("37JiNBym250ye3aUJ04RaZg3SFSP03qJ8FR/I1JckVI="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256AndDefaultFormat.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithSha256AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha256() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-256");
-
-		Assert.assertTrue(result.equals("37JiNBym250ye3aUJ04RaZg3SFSP03qJ8FR/I1JckVI="));
-	}
+    @Test
+    public void hashBinaryWithSha256() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-256");
+            assertTrue(result.equals("37JiNBym250ye3aUJ04RaZg3SFSP03qJ8FR/I1JckVI="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha256AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class HashBinaryWithSha384 extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha384() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-384", "base64");		
-
-		Assert.assertTrue(result.equals("DcQ3caBftiQCIQn96Pr8PC2vzs17Re0tZ8/CZnOoucu/N+818uqAXxR7l9oxYgoW"));
-	}
+    @Test
+    public void hashBinaryWithSha384() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-384", "base64");
+            assertTrue(result.equals("DcQ3caBftiQCIQn96Pr8PC2vzs17Re0tZ8/CZnOoucu/N+818uqAXxR7l9oxYgoW"));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384AndDefaultFormat.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashBinaryWithSha384AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha384() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-384");		
-
-		Assert.assertTrue(result.equals("DcQ3caBftiQCIQn96Pr8PC2vzs17Re0tZ8/CZnOoucu/N+818uqAXxR7l9oxYgoW"));
-	}
+    @Test
+    public void hashBinaryWithSha384() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-384");
+            assertTrue(result.equals("DcQ3caBftiQCIQn96Pr8PC2vzs17Re0tZ8/CZnOoucu/N+818uqAXxR7l9oxYgoW"));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha384AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashBinaryWithSha512 extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha512() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-512", "base64");
-
-		Assert.assertTrue(result.equals("Be+hlGy9TNibbaE+6DA2gu6kNj2GS+7b4egFcJDMzQSFQiGgFtTh/mD61ta4pDvc+jqHFlqOyJLH\r\nirkROd86Mw=="));
-	}
+    @Test
+    public void hashBinaryWithSha512() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-512", "base64");
+            assertTrue(result.equals("Be+hlGy9TNibbaE+6DA2gu6kNj2GS+7b4egFcJDMzQSFQiGgFtTh/mD61ta4pDvc+jqHFlqOyJLH\r\nirkROd86Mw=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512AndDefaultFormat.java
@@ -2,19 +2,19 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashBinaryWithSha512AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithSha512() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../keystore.ks");
-		String result = Hash.hashBinary(input, "SHA-512");
-
-		Assert.assertTrue(result.equals("Be+hlGy9TNibbaE+6DA2gu6kNj2GS+7b4egFcJDMzQSFQiGgFtTh/mD61ta4pDvc+jqHFlqOyJLH\r\nirkROd86Mw=="));
-	}
+    @Test
+    public void hashBinaryWithSha512() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-512");
+            assertTrue(result.equals("Be+hlGy9TNibbaE+6DA2gu6kNj2GS+7b4egFcJDMzQSFQiGgFtTh/mD61ta4pDvc+jqHFlqOyJLH\r\nirkROd86Mw=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithSha512AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithm.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithm.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithm.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithm.java
@@ -3,23 +3,21 @@ package ro.kuberam.libs.java.crypto.digest;
 import java.io.InputStream;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashBinaryWithWrongAlgorithm extends BaseTest {
 
-	@Test
-	public void hashBinaryWithWrongAlgorithm() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../../keystore.ks");
-		
-		try {
-			String result = Hash.hashBinary(input, "SHA-17", "base64");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_unknownAlgorithm));
-		}
-	}
+    @Test
+    public void hashBinaryWithWrongAlgorithm() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../../keystore.ks");) {
+            final String result = Hash.hashBinary(input, "SHA-17", "base64");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_unknownAlgorithm));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithmAndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithmAndDefaultFormat.java
@@ -3,23 +3,21 @@ package ro.kuberam.libs.java.crypto.digest;
 import java.io.InputStream;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashBinaryWithWrongAlgorithmAndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashBinaryWithWrongAlgorithm() throws Exception {
-		InputStream input = getClass().getResourceAsStream("../../keystore.ks");
-		
-		try {
-			String result = Hash.hashBinary(input, "SHA-17");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_unknownAlgorithm));
-		}
-	}
+    @Test
+    public void hashBinaryWithWrongAlgorithm() throws Exception {
+        try (final InputStream input = getClass().getResourceAsStream("../../keystore.ks")) {
+            final String result = Hash.hashBinary(input, "SHA-17");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_unknownAlgorithm));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithmAndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashBinaryWithWrongAlgorithmAndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeBinaryWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeBinaryWithMd5.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeBinaryWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeBinaryWithMd5.java
@@ -1,21 +1,20 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import java.io.FileInputStream;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
 import ro.kuberam.tests.junit.BaseTest;
 
 public class HashLargeBinaryWithMd5 extends BaseTest {
 
-	@Test
-	public void hashLargeBinaryWithMd5() throws Exception {
-		String result = Hash.hashBinary(new FileInputStream(generate5MbTempFile()), "MD5", "base64");
-		
-		System.out.println(result);
-
-		Assert.assertTrue(result.equals("fSAcOQGKiTzr20UUJWNpaQ=="));
-	}
+    @Test
+    public void hashLargeBinaryWithMd5() throws Exception {
+        try (final InputStream is = Files.newInputStream(generate5MbTempFile().toPath())) {
+            final String result = Hash.hashBinary(is, "MD5", "base64");
+            Assert.assertTrue(result.equals("fSAcOQGKiTzr20UUJWNpaQ=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeStringWithMd5.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashLargeStringWithMd5.java
@@ -1,20 +1,17 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import org.apache.commons.io.IOUtils;
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashLargeStringWithMd5 extends BaseTest {
 
-	@Test
-	public void hashLargeStringWithMd5() throws Exception {
-		String result = Hash.hashString(generate5MbTempString(), "MD5", "base64");
-		
-		System.out.println(result);
-
-		Assert.assertTrue(result.equals("0oZeT8dy8rR/aqDYUz3sCw=="));
-	}
+    @Test
+    public void hashLargeStringWithMd5() throws Exception {
+        final String result = Hash.hashString(generate5MbTempString(), "MD5", "base64");
+        System.out.println(result);
+        assertTrue(result.equals("0oZeT8dy8rR/aqDYUz3sCw=="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashPerformanceTest.java
@@ -2,126 +2,110 @@ package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashPerformanceTest extends BaseTest {
-	
-	private static File tempFile;
-	private static InputStream tempFileIs;	
-	private static byte[] tempBa;
-	private static String tempString;
 
-	@BeforeClass
-	public static void initialize() throws IOException {
-		tempFile = generate5MbTempFile();
-		tempFileIs = new FileInputStream(tempFile);
-		
-		//
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		int next = tempFileIs.read();
-		while (next > -1) {
-		    bos.write(next);
-		    next = tempFileIs.read();
-		}
-		bos.flush();		
-		tempBa = bos.toByteArray();
-		
-		tempString = generate5MbTempString();
-	}
+    private static Path tempFile;
+    private static String tempString;
 
-	@Test
-	public void digestInputStreamWithFileInputStreamTest() throws Exception {
+    @BeforeClass
+    public static void initialize() throws IOException {
+        tempFile = generate5MbTempFile().toPath();
+        tempString = generate5MbTempString();
+    }
 
-		MessageDigest algorithm = MessageDigest.getInstance("SHA");
-		DigestInputStream dis = new DigestInputStream(tempFileIs, algorithm);
+    @Test
+    public void digestInputStreamWithFileInputStreamTest() throws Exception {
 
-		// read the file and update the hash calculation
-		while (dis.read() != -1)
-			;
+        final MessageDigest algorithm = MessageDigest.getInstance("SHA");
+        try (final DigestInputStream dis = new DigestInputStream(Files.newInputStream(tempFile), algorithm)) {
 
-		// get the hash value as byte array
-		byte[] hash = algorithm.digest();
-		
-		Assert.assertTrue(hash.length == 20);
-	}
-	
-	@Test
-	public void digestInputStreamWithBufferedInputStreamTest() throws Exception {
+            // read the file and update the hash calculation
+            while (dis.read() != -1)
+                ;
 
-		BufferedInputStream bis = new BufferedInputStream(tempFileIs);
-		MessageDigest algorithm = MessageDigest.getInstance("SHA");
-		DigestInputStream dis = new DigestInputStream(bis, algorithm);
+            // get the hash value as byte array
+            byte[] hash = algorithm.digest();
 
-		// read the file and update the hash calculation
-		while (dis.read() != -1)
-			;
+            assertTrue(hash.length == 20);
+        }
+    }
 
-		// get the hash value as byte array
-		byte[] hash = algorithm.digest();
-		
-		Assert.assertTrue(hash.length == 20);
-	}
-	
-	@Test
-	public void digestStringWithInputStreamTest() throws Exception {
-		
-		InputStream is = null;
-		
-        is = new ByteArrayInputStream(tempString.getBytes(StandardCharsets.UTF_8));
-		
-		MessageDigest algorithm = MessageDigest.getInstance("SHA");
-		DigestInputStream dis = new DigestInputStream(is, algorithm);
+    @Test
+    public void digestInputStreamWithBufferedInputStreamTest() throws Exception {
+        final MessageDigest algorithm = MessageDigest.getInstance("SHA");
+        try (final BufferedInputStream bis = new BufferedInputStream(Files.newInputStream(tempFile));
+             final DigestInputStream dis = new DigestInputStream(bis, algorithm)) {
 
-		// read the file and update the hash calculation
-		while (dis.read() != -1)
-			;
+            // read the file and update the hash calculation
+            while (dis.read() != -1)
+                ;
 
-		// get the hash value as byte array
-		byte[] hash = algorithm.digest();
-		
-		Assert.assertTrue(hash.length == 20);
-	}
-	
-	@Test
-	public void digestString() throws Exception {
-		
-		MessageDigest algorithm = MessageDigest.getInstance("SHA");
-		algorithm.update(tempString.getBytes(StandardCharsets.UTF_8));
-		byte[] hash = algorithm.digest();
-		
-		Assert.assertTrue(hash.length == 20);
-	}	
-	
-	@Test
-	@Ignore("too slow")
-	public void digestWithByteArrayOutputStreamTest() throws Exception {
-		
-		int tempByteArrayLength = tempBa.length;
-		MessageDigest algorithm = MessageDigest.getInstance("SHA");
-		
-		while (tempByteArrayLength > 0) {
-			algorithm.update(tempBa, 0, tempByteArrayLength);
-			tempByteArrayLength = tempBa.length;
-		}
+            // get the hash value as byte array
+            final byte[] hash = algorithm.digest();
 
-		// get the hash value as byte array
-		byte[] hash = algorithm.digest();
-		
-		Assert.assertTrue(hash.length == 20);
-	}	
+            assertTrue(hash.length == 20);
+        }
+    }
+
+    @Test
+    public void digestStringWithInputStreamTest() throws Exception {
+
+        MessageDigest algorithm = MessageDigest.getInstance("SHA");
+        try (final InputStream is = new ByteArrayInputStream(tempString.getBytes(StandardCharsets.UTF_8));
+             final DigestInputStream dis = new DigestInputStream(is, algorithm)) {
+
+            // read the file and update the hash calculation
+            while (dis.read() != -1)
+                ;
+
+            // get the hash value as byte array
+            final byte[] hash = algorithm.digest();
+
+            assertTrue(hash.length == 20);
+        }
+    }
+
+    @Test
+    public void digestString() throws Exception {
+        final MessageDigest algorithm = MessageDigest.getInstance("SHA");
+        algorithm.update(tempString.getBytes(StandardCharsets.UTF_8));
+        final byte[] hash = algorithm.digest();
+
+        assertTrue(hash.length == 20);
+    }
+
+    @Test
+    @Ignore("too slow")
+    public void digestWithByteArrayOutputStreamTest() throws Exception {
+        final byte[] tempBa = Files.readAllBytes(tempFile);
+        int tempByteArrayLength = tempBa.length;
+        final MessageDigest algorithm = MessageDigest.getInstance("SHA");
+
+        while (tempByteArrayLength > 0) {
+            algorithm.update(tempBa, 0, tempByteArrayLength);
+            tempByteArrayLength = tempBa.length;
+        }
+
+        // get the hash value as byte array
+        final byte[] hash = algorithm.digest();
+
+        assertTrue(hash.length == 20);
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashPerformanceTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.BufferedInputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithMd5 extends BaseTest {
 
-	@Test
-	public void hashStringWithMd5hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "MD5", "base64");
-
-		Assert.assertTrue(result
-				.equals("use1oAoe8vIgnFgygz2OKw=="));
-	}
+    @Test
+    public void hashStringWithMd5hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "MD5", "base64");
+        assertTrue(result
+                .equals("use1oAoe8vIgnFgygz2OKw=="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithMd5AndDefaultFormat.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithMd5AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashStringWithMd5hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "MD5");
-
-		Assert.assertTrue(result
-				.equals("use1oAoe8vIgnFgygz2OKw=="));		
-	}
+    @Test
+    public void hashStringWithMd5hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "MD5");
+        assertTrue(result
+                .equals("use1oAoe8vIgnFgygz2OKw=="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha1 extends BaseTest {
 
-	@Test
-	public void hashStringWithSha1hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-1", "base64");
-
-		Assert.assertTrue(result
-				.equals("cV2wx17vo8eH2TaFRvCIIvJjNqU="));
-	}
+    @Test
+    public void hashStringWithSha1hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-1", "base64");
+        assertTrue(result
+                .equals("cV2wx17vo8eH2TaFRvCIIvJjNqU="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha1AndDefaultFormat.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha1AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashStringWithSha1hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-1");
-
-		Assert.assertTrue(result
-				.equals("cV2wx17vo8eH2TaFRvCIIvJjNqU="));		
-	}
+    @Test
+    public void hashStringWithSha1hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-1");
+        assertTrue(result
+                .equals("cV2wx17vo8eH2TaFRvCIIvJjNqU="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256.java
@@ -6,15 +6,15 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha256 extends BaseTest {
 
-	@Test
-	public void hashStringWithSha256hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-256", "base64");
-
-		Assert.assertTrue(result
-				.equals("E+B0JzLRgxm2+1rB8qIZoQ2Qn+JLxwJCWORv46fKhMM="));
-	}
+    @Test
+    public void hashStringWithSha256hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-256", "base64");
+        assertTrue(result
+                .equals("E+B0JzLRgxm2+1rB8qIZoQ2Qn+JLxwJCWORv46fKhMM="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256AndDefaultFormat.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha256AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashStringWithSha256hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-256");
-
-		Assert.assertTrue(result
-				.equals("E+B0JzLRgxm2+1rB8qIZoQ2Qn+JLxwJCWORv46fKhMM="));		
-	}
+    @Test
+    public void hashStringWithSha256hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-256");
+        assertTrue(result
+                .equals("E+B0JzLRgxm2+1rB8qIZoQ2Qn+JLxwJCWORv46fKhMM="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha256AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha384 extends BaseTest {
 
-	@Test
-	public void hashStringWithSha384hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-384", "base64");
-
-		Assert.assertTrue(result
-				.equals("F4CFDSBHm+Bm400bOgH2q2IbIUj8XRUBWf0inx7lrN0T8IHz9scGVmJoGZ2+s1La"));
-	}
+    @Test
+    public void hashStringWithSha384hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-384", "base64");
+        assertTrue(result
+                .equals("F4CFDSBHm+Bm400bOgH2q2IbIUj8XRUBWf0inx7lrN0T8IHz9scGVmJoGZ2+s1La"));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha384AndDefaultFormat.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha384AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashStringWithSha384hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-384");
-
-		Assert.assertTrue(result
-				.equals("F4CFDSBHm+Bm400bOgH2q2IbIUj8XRUBWf0inx7lrN0T8IHz9scGVmJoGZ2+s1La"));
-	}
+    @Test
+    public void hashStringWithSha384hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-384");
+        assertTrue(result
+                .equals("F4CFDSBHm+Bm400bOgH2q2IbIUj8XRUBWf0inx7lrN0T8IHz9scGVmJoGZ2+s1La"));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha512 extends BaseTest {
 
-	@Test
-	public void hashStringWithSha512hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-512", "base64");
-
-		Assert.assertTrue(result
-				.equals("+YpeZRBrctlL1xr6plZOScp/6ArUw3GihjtKys1e3qQ6/aWLFjoOFEfuiUJA3uLIkebH1OG+rDdM\r\nFZ0+/JFK2g=="));
-	}
+    @Test
+    public void hashStringWithSha512hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-512", "base64");
+        assertTrue(result
+                .equals("+YpeZRBrctlL1xr6plZOScp/6ArUw3GihjtKys1e3qQ6/aWLFjoOFEfuiUJA3uLIkebH1OG+rDdM\r\nFZ0+/JFK2g=="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HashStringWithSha512AndDefaultFormat.java
@@ -1,20 +1,18 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import ro.kuberam.libs.java.crypto.digest.Hash;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HashStringWithSha512AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hashStringWithSha512hexOutput() throws Exception {
-		String input = "Short string for tests.";
-		
-		String result = Hash.hashString(input, "SHA-512");
-
-		Assert.assertTrue(result
-				.equals("+YpeZRBrctlL1xr6plZOScp/6ArUw3GihjtKys1e3qQ6/aWLFjoOFEfuiUJA3uLIkebH1OG+rDdM\r\nFZ0+/JFK2g=="));
-	}
+    @Test
+    public void hashStringWithSha512hexOutput() throws Exception {
+        final String input = "Short string for tests.";
+        final String result = Hash.hashString(input, "SHA-512");
+        assertTrue(result
+                .equals("+YpeZRBrctlL1xr6plZOScp/6ArUw3GihjtKys1e3qQ6/aWLFjoOFEfuiUJA3uLIkebH1OG+rDdM\r\nFZ0+/JFK2g=="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
@@ -1,28 +1,25 @@
 package ro.kuberam.libs.java.crypto.digest;
 
-import java.io.FileInputStream;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-import org.apache.commons.io.IOUtils;
-
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
 public class HmacLargeBinaryWithSha1 extends BaseTest {
 
-	@Test
-	public void hmacLargeBinaryWithSha1() throws Exception {
-		String input = IOUtils.toString(new FileInputStream(generate5MbTempFile()));
-		String secretKey = "/hWLmb8xRM75bOS6fyV9Pn0mf3Aiw+HphRCL8nOq";
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
-				secretKey.getBytes(StandardCharsets.UTF_8), "HMAC-SHA-1", "base64");
+    @Test
+    public void hmacLargeBinaryWithSha1() throws Exception {
+        final String input = new String(Files.readAllBytes(generate5MbTempFile().toPath()), UTF_8);
+        String secretKey = "/hWLmb8xRM75bOS6fyV9Pn0mf3Aiw+HphRCL8nOq";
+        String result = Hmac.hmac(input.getBytes(UTF_8),
+                secretKey.getBytes(UTF_8), "HMAC-SHA-1", "base64");
 
-		System.out.println(result);
+        System.out.println(result);
 
-		Assert.assertTrue(result.equals("McKrpaWMrn0fzAlfw0yVDxy9esE="));
-	}
+        assertTrue(result.equals("McKrpaWMrn0fzAlfw0yVDxy9esE="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
@@ -19,6 +19,7 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.InputStream;
 import java.nio.file.Files;
 
 import org.junit.Test;
@@ -33,12 +34,25 @@ public class HmacLargeBinaryWithSha1 extends BaseTest {
     @Test
     public void hmacLargeBinaryWithSha1() throws Exception {
         final String input = new String(Files.readAllBytes(generate5MbTempFile().toPath()), UTF_8);
-        String secretKey = "/hWLmb8xRM75bOS6fyV9Pn0mf3Aiw+HphRCL8nOq";
-        String result = Hmac.hmac(input.getBytes(UTF_8),
+        final String secretKey = "/hWLmb8xRM75bOS6fyV9Pn0mf3Aiw+HphRCL8nOq";
+        final String result = Hmac.hmac(input.getBytes(UTF_8),
                 secretKey.getBytes(UTF_8), "HMAC-SHA-1", "base64");
 
         System.out.println(result);
 
         assertTrue(result.equals("McKrpaWMrn0fzAlfw0yVDxy9esE="));
+    }
+
+    @Test
+    public void hmacLargeBinaryWithSha1_inputStream() throws Exception {
+        try(final InputStream is = Files.newInputStream(generate5MbTempFile().toPath())) {
+            final String secretKey = "/hWLmb8xRM75bOS6fyV9Pn0mf3Aiw+HphRCL8nOq";
+            final String result = Hmac.hmac(is,
+                    secretKey.getBytes(UTF_8), "HMAC-SHA-1", "base64");
+
+            System.out.println(result);
+
+            assertTrue(result.equals("McKrpaWMrn0fzAlfw0yVDxy9esE="));
+        }
     }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacLargeBinaryWithSha1.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.nio.file.Files;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
@@ -1,25 +1,27 @@
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithMd5 extends BaseTest {
 
-	@Test
-	public void hmacStringWithMd5() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
-		String secretKey = IOUtils.toString(secretKeyIs);
+    @Test
+    public void hmacStringWithMd5() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+            final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
-				secretKey.getBytes(StandardCharsets.UTF_8), "HMAC-MD5", "base64");
+            final String result = Hmac.hmac(input.getBytes(UTF_8),
+                    secretKey.getBytes(UTF_8), "HMAC-MD5", "base64");
 
-		Assert.assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
-	}
+            assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5.java
@@ -19,6 +19,7 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
@@ -38,6 +39,20 @@ public class HmacStringWithMd5 extends BaseTest {
             final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
 
             final String result = Hmac.hmac(input.getBytes(UTF_8),
+                    secretKey.getBytes(UTF_8), "HMAC-MD5", "base64");
+
+            assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithMd5_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+                final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+            final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
+
+            final String result = Hmac.hmac(is,
                     secretKey.getBytes(UTF_8), "HMAC-MD5", "base64");
 
             assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
@@ -19,6 +19,7 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
@@ -38,6 +39,20 @@ public class HmacStringWithMd5AndDefaultFormat extends BaseTest {
             final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
 
             final String result = Hmac.hmac(input.getBytes(UTF_8),
+                    secretKey.getBytes(UTF_8), "HMAC-MD5", "");
+
+            assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithMd5_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+                final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+            final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
+
+            final String result = Hmac.hmac(is,
                     secretKey.getBytes(UTF_8), "HMAC-MD5", "");
 
             assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithMd5AndDefaultFormat.java
@@ -1,26 +1,27 @@
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithMd5AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hmacStringWithMd5() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
-		String secretKey = IOUtils.toString(secretKeyIs);
+    @Test
+    public void hmacStringWithMd5() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+            final String secretKey = IOUtils.toString(secretKeyIs, UTF_8);
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
-				secretKey.getBytes(StandardCharsets.UTF_8), "HMAC-MD5", "");
+            final String result = Hmac.hmac(input.getBytes(UTF_8),
+                    secretKey.getBytes(UTF_8), "HMAC-MD5", "");
 
-		Assert.assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
-	}
+            assertTrue(result.equals("l4MY6Yosjo7W60VJeXB/PQ=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
@@ -19,6 +19,7 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -28,6 +29,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha1 extends BaseTest {
@@ -38,6 +40,19 @@ public class HmacStringWithSha1 extends BaseTest {
         try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
             final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-1", "base64");
+
+            assertTrue(result.equals("55LyDq7GFnqijauK4CQWR4AqyZk="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha1_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+                final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-1", "base64");
 
             assertTrue(result.equals("55LyDq7GFnqijauK4CQWR4AqyZk="));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1.java
@@ -5,23 +5,23 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha1 extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha1() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha1() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-1", "base64");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-1", "base64");
 
-		Assert.assertTrue(result.equals("55LyDq7GFnqijauK4CQWR4AqyZk="));
-	}
+            assertTrue(result.equals("55LyDq7GFnqijauK4CQWR4AqyZk="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
@@ -5,20 +5,19 @@ import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
 import ro.kuberam.tests.junit.BaseTest;
 
 public class HmacStringWithSha1AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha1() throws Exception {
-		String input = "abc";
+    @Test
+    public void hmacStringWithSha1() throws Exception {
+        final String input = "abc";
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
-				"def".getBytes(StandardCharsets.UTF_8), "HMAC-SHA-1", "");
+        final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
+                "def".getBytes(StandardCharsets.UTF_8), "HMAC-SHA-1", "");
 
-		System.out.println(result);
+        System.out.println(result);
 
-		Assert.assertTrue(result.equals("dYTuFEkwcs2NmuhQ4P8JBTgjD4w="));
-	}
+        Assert.assertTrue(result.equals("dYTuFEkwcs2NmuhQ4P8JBTgjD4w="));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha1AndDefaultFormat.java
@@ -19,12 +19,16 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class HmacStringWithSha1AndDefaultFormat extends BaseTest {
 
@@ -38,5 +42,19 @@ public class HmacStringWithSha1AndDefaultFormat extends BaseTest {
         System.out.println(result);
 
         Assert.assertTrue(result.equals("dYTuFEkwcs2NmuhQ4P8JBTgjD4w="));
+    }
+
+    @Test
+    public void hmacStringWithSha1_withInputStream() throws Exception {
+        final String input = "abc";
+
+        try(final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8))) {
+            final String result = Hmac.hmac(is,
+                    "def".getBytes(StandardCharsets.UTF_8), "HMAC-SHA-1", "");
+
+            System.out.println(result);
+
+            Assert.assertTrue(result.equals("dYTuFEkwcs2NmuhQ4P8JBTgjD4w="));
+        }
     }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
@@ -3,31 +3,32 @@ package ro.kuberam.libs.java.crypto.digest;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha256 extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha256() throws Exception {
-		String input = "20120215";
+    @Test
+    public void hmacStringWithSha256() throws Exception {
+        final String input = "20120215";
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
-				"AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".getBytes(StandardCharsets.UTF_8),
-				"HMAC-SHA-256", "base64");
-		System.out.println(result);
+        String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
+                "AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".getBytes(StandardCharsets.UTF_8),
+                "HMAC-SHA-256", "base64");
+        System.out.println(result);
 
-		result = Hmac.hmac("us-east-1".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
-		System.out.println(result);
+        result = Hmac.hmac("us-east-1".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
+        System.out.println(result);
 
-		result = Hmac.hmac("iam".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
-		System.out.println(result);
+        result = Hmac.hmac("iam".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
+        System.out.println(result);
 
-		result = Hmac.hmac("aws4_request".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "hex");
-		System.out.println(result);
+        result = Hmac.hmac("aws4_request".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "hex");
+        System.out.println(result);
 
-		Assert.assertTrue(result.equals("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"));
-	}
+        assertTrue(result.equals("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"));
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.nio.charset.StandardCharsets;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256.java
@@ -19,6 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
@@ -26,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha256 extends BaseTest {
@@ -33,8 +36,29 @@ public class HmacStringWithSha256 extends BaseTest {
     @Test
     public void hmacStringWithSha256() throws Exception {
         final String input = "20120215";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8))) {
+            String result = Hmac.hmac(is,
+                    "AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".getBytes(StandardCharsets.UTF_8),
+                    "HMAC-SHA-256", "base64");
+            System.out.println(result);
 
-        String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8),
+            result = Hmac.hmac("us-east-1".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
+            System.out.println(result);
+
+            result = Hmac.hmac("iam".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "base64");
+            System.out.println(result);
+
+            result = Hmac.hmac("aws4_request".getBytes(StandardCharsets.UTF_8), Base64.getDecoder().decode(result), "HMAC-SHA-256", "hex");
+            System.out.println(result);
+
+            assertTrue(result.equals("f4780e2d9f65fa895f9c67b32ce1baf0b0d8a43505a000a1a9e090d414db404d"));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha256_inputStream() throws Exception {
+        final String input = "20120215";
+        String result = Hmac.hmac(input.getBytes(UTF_8),
                 "AWS4wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY".getBytes(StandardCharsets.UTF_8),
                 "HMAC-SHA-256", "base64");
         System.out.println(result);

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
@@ -19,8 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha256AndDefaultFormat extends BaseTest {
@@ -35,9 +36,23 @@ public class HmacStringWithSha256AndDefaultFormat extends BaseTest {
     @Test
     public void hmacStringWithSha256() throws Exception {
         final String input = "Short string for tests.";
-        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+        try(final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(input.getBytes(UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-256", "");
+
+            assertTrue(result.equals("FfZidcLEUg4oJLIZfw6xHlPMz8KPHxo2liaBKgLfcOE="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha256_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+             final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-256", "");
 
             assertTrue(result.equals("FfZidcLEUg4oJLIZfw6xHlPMz8KPHxo2liaBKgLfcOE="));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha256AndDefaultFormat.java
@@ -5,23 +5,23 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha256AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha256() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha256() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-256", "");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-256", "");
 
-		Assert.assertTrue(result.equals("FfZidcLEUg4oJLIZfw6xHlPMz8KPHxo2liaBKgLfcOE="));
-	}
+            assertTrue(result.equals("FfZidcLEUg4oJLIZfw6xHlPMz8KPHxo2liaBKgLfcOE="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
@@ -5,23 +5,23 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha384 extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha384() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha384() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-384", "base64");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-384", "base64");
 
-		Assert.assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
-	}
+            assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384.java
@@ -19,8 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha384 extends BaseTest {
@@ -37,7 +38,20 @@ public class HmacStringWithSha384 extends BaseTest {
         final String input = "Short string for tests.";
         try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+            final String result = Hmac.hmac(input.getBytes(UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-384", "base64");
+
+            assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha384_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+             final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-384", "base64");
 
             assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
@@ -19,8 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha384AndDefaultFormat extends BaseTest {
@@ -37,7 +38,20 @@ public class HmacStringWithSha384AndDefaultFormat extends BaseTest {
         final String input = "Short string for tests.";
         try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+            final String result = Hmac.hmac(input.getBytes(UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-384", "");
+
+            assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha384_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+             final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-384", "");
 
             assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
@@ -5,23 +5,23 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha384AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha384() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha384() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-384", "");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-384", "");
 
-		Assert.assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
-	}
+            assertTrue(result.equals("RRirKZTmx+cG8EXvgrRnpYFPEPYXaZBirY+LFmiUBAK61LCryDsL4clFRG5/BcBr"));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha384AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
@@ -5,24 +5,24 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha512 extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha512() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha512() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-512", "base64");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-512", "base64");
 
-		Assert.assertTrue(result
-				.equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
-	}
+            assertTrue(result
+                    .equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
@@ -19,8 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha512 extends BaseTest {
@@ -37,7 +38,21 @@ public class HmacStringWithSha512 extends BaseTest {
         final String input = "Short string for tests.";
         try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+            final String result = Hmac.hmac(input.getBytes(UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-512", "base64");
+
+            assertTrue(result
+                    .equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha512_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+             final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-512", "base64");
 
             assertTrue(result

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
@@ -5,24 +5,24 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
-import ro.kuberam.libs.java.crypto.digest.Hmac;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class HmacStringWithSha512AndDefaultFormat extends BaseTest {
 
-	@Test
-	public void hmacStringWithSha512AndDefaultProvider() throws Exception {
-		String input = "Short string for tests.";
-		InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key");
+    @Test
+    public void hmacStringWithSha512AndDefaultProvider() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-		String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
-				"HMAC-SHA-512", "");
+            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-512", "");
 
-		Assert.assertTrue(result
-				.equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
-	}
+            assertTrue(result
+                    .equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digest;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digest/HmacStringWithSha512AndDefaultFormat.java
@@ -19,8 +19,8 @@
  */
 package ro.kuberam.libs.java.crypto.digest;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertTrue;
 
 public class HmacStringWithSha512AndDefaultFormat extends BaseTest {
@@ -37,7 +38,21 @@ public class HmacStringWithSha512AndDefaultFormat extends BaseTest {
         final String input = "Short string for tests.";
         try (final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
 
-            final String result = Hmac.hmac(input.getBytes(StandardCharsets.UTF_8), IOUtils.toByteArray(secretKeyIs),
+            final String result = Hmac.hmac(input.getBytes(UTF_8), IOUtils.toByteArray(secretKeyIs),
+                    "HMAC-SHA-512", "");
+
+            assertTrue(result
+                    .equals("z9MtEpBXxO5bKmsXJWfKsZ4v+RduKU89Y95H2HMGQEwHGefWmewNNQ7urZVuWEU5aeRRdO7G7j0QlcLYv1pkrg=="));
+        }
+    }
+
+    @Test
+    public void hmacStringWithSha512AndDefaultProvider_inputStream() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = new ByteArrayInputStream(input.getBytes(UTF_8));
+             final InputStream secretKeyIs = getClass().getResourceAsStream("../rsa-private-key.key")) {
+
+            final String result = Hmac.hmac(is, IOUtils.toByteArray(secretKeyIs),
                     "HMAC-SHA-512", "");
 
             assertTrue(result

--- a/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateDigitalSignatureTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateDigitalSignatureTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.nio.file.Paths;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateEnvelopedDigitalSignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateEnvelopedDigitalSignature.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateEnvelopedDigitalSignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/GenerateEnvelopedDigitalSignature.java
@@ -3,23 +3,25 @@ package ro.kuberam.libs.java.crypto.digitalSignature;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
-import ro.kuberam.libs.java.crypto.digitalSignature.GenerateXmlSignature;
-import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
 public class GenerateEnvelopedDigitalSignature extends BaseTest {
 
-	@Test
-	public void generateEnvelopedDigitalSignature() throws Exception {
-		InputStream inputIs = getClass().getResourceAsStream("../doc-1.xml");
-		Document input = parseXmlString(IOUtils.toString(inputIs));
-		String[] certificateDetails = new String[5];
-		certificateDetails[0] = "";		
-		String signatureString = GenerateXmlSignature.generate(input, "inclusive", "SHA1", "DSA_SHA1", "dsig", "enveloped", null, certificateDetails, null);
+    @Test
+    public void generateEnvelopedDigitalSignature() throws Exception {
+        try (final InputStream inputIs = getClass().getResourceAsStream("../doc-1.xml")) {
+            final Document input = parseXmlString(IOUtils.toString(inputIs, UTF_8));
+            final String[] certificateDetails = new String[5];
+            certificateDetails[0] = "";
+            final String signatureString = GenerateXmlSignature.generate(input, "inclusive", "SHA1", "DSA_SHA1", "dsig", "enveloped", null, certificateDetails, null);
 
-		Assert.assertTrue(signatureString.contains("/KaCzo4Syrom78z3EQ5SbbB4sF7ey80etKII864WF64B81uRpH5t9jQTxeEu0ImbzRMqzVDZkVG9\nxD7nN1kuFw=="));
-	}
+            assertTrue(signatureString.contains("/KaCzo4Syrom78z3EQ5SbbB4sF7ey80etKII864WF64B81uRpH5t9jQTxeEu0ImbzRMqzVDZkVG9\nxD7nN1kuFw=="));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateEnvelopedDigitalSignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateEnvelopedDigitalSignature.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.digitalSignature;
 
 import java.io.InputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateEnvelopedDigitalSignature.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/digitalSignature/ValidateEnvelopedDigitalSignature.java
@@ -3,25 +3,26 @@ package ro.kuberam.libs.java.crypto.digitalSignature;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
-import ro.kuberam.libs.java.crypto.digitalSignature.GenerateXmlSignature;
-import ro.kuberam.libs.java.crypto.digitalSignature.ValidateXmlSignature;
-import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+
 public class ValidateEnvelopedDigitalSignature extends BaseTest {
 
-	@Test
-	public void test() throws Exception {
-		InputStream inputIs = getClass().getResourceAsStream("../doc-1.xml");
-		Document input = parseXmlString(IOUtils.toString(inputIs));
-		String[] certificateDetails = new String[5];
-		certificateDetails[0] = "";		
-		String signatureString = GenerateXmlSignature.generate(input, "inclusive", "SHA1", "DSA_SHA1", "dsig", "enveloped", null, certificateDetails, null);
-		Document signature = parseXmlString(signatureString);
-		boolean validateSignature = ValidateXmlSignature.validate(signature);
-		Assert.assertTrue(validateSignature);
-	}
+    @Test
+    public void test() throws Exception {
+        try (final InputStream inputIs = getClass().getResourceAsStream("../doc-1.xml")) {
+            final Document input = parseXmlString(IOUtils.toString(inputIs, UTF_8));
+            final String[] certificateDetails = new String[5];
+            certificateDetails[0] = "";
+            final String signatureString = GenerateXmlSignature.generate(input, "inclusive", "SHA1", "DSA_SHA1", "dsig", "enveloped", null, certificateDetails, null);
+            final Document signature = parseXmlString(signatureString);
+            final boolean validateSignature = ValidateXmlSignature.validate(signature);
+            assertTrue(validateSignature);
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
@@ -1,22 +1,22 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class DecryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode extends BaseTest {
 
-	@Test
-	public void decryptStringWithAesSymmetricKey() throws Exception {
-		String input = "51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54";
-		String plainKey = "1234567890123456";
-		String iv = Hash.hashString("initialization vector", "MD5", "");
-		
-		String result = SymmetricEncryption.decryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
+    @Test
+    public void decryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54";
+        final String plainKey = "1234567890123456";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		Assert.assertTrue(result.equals("Short string for tests."));
-	}
+        final String result = SymmetricEncryption.decryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
+
+        assertEquals("Short string for tests.", result);
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyCbcMode.java
@@ -1,22 +1,22 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class DecryptStringWithAesSymmetricKeyCbcMode extends BaseTest {
 
-	@Test
-	public void decryptStringWithAesSymmetricKey() throws Exception {
-		String input = "51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54";
-		String plainKey = "1234567890123456";
-		String iv = Hash.hashString("initialization vector", "MD5", "");
-		
-		String result = SymmetricEncryption.decryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
+    @Test
+    public void decryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54";
+        final String plainKey = "1234567890123456";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		Assert.assertTrue(result.equals("Short string for tests."));
-	}
+        final String result = SymmetricEncryption.decryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
+
+        assertEquals("Short string for tests.", result);
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyEcbMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyEcbMode.java
@@ -1,20 +1,20 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class DecryptStringWithAesSymmetricKeyEcbMode extends BaseTest {
 
-	@Test
-	public void decryptStringWithAesSymmetricKey() throws Exception {
-		String input = "222-157-20-54-132-99-46-30-73-43-253-148-61-155-86-141-51-56-40-42-31-168-189-56-236-102-58-237-175-171-9-87";
-		String plainKey = "1234567890123456";
-		
-		String result = SymmetricEncryption.decryptString(input, plainKey, "AES", "", "SunJCE");
+    @Test
+    public void decryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "222-157-20-54-132-99-46-30-73-43-253-148-61-155-86-141-51-56-40-42-31-168-189-56-236-102-58-237-175-171-9-87";
+        final String plainKey = "1234567890123456";
 
-		Assert.assertTrue(result.equals("Short string for tests."));
-	}
+        final String result = SymmetricEncryption.decryptString(input, plainKey, "AES", "", "SunJCE");
+
+        assertEquals("Short string for tests.", result);
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyEcbMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/DecryptStringWithAesSymmetricKeyEcbMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
@@ -1,22 +1,22 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class EncryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String plainKey = "1234567890123456";
-		String iv = Hash.hashString("initialization vector", "MD5", "");
-		
-		String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
+    @Test
+    public void encryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        final String plainKey = "1234567890123456";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		Assert.assertTrue(result.equals("51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54"));
-	}
+        final String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
+
+        assertEquals("51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54", result);
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyAndDefaultProviderCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyCbcMode.java
@@ -1,23 +1,23 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class EncryptStringWithAesSymmetricKeyCbcMode extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String plainKey = "1234567890123456";
-		String iv = Hash.hashString("initialization vector", "MD5", "");		
-		
-		String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
+    @Test
+    public void encryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        final String plainKey = "1234567890123456";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		Assert.assertTrue(result.equals("51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54"));
-	}
+        final String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
+
+        assertEquals("51-143-171-200-187-20-34-252-231-243-254-42-36-13-9-123-191-251-243-42-3-238-193-13-155-168-139-67-135-3-143-54", result);
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyEcbMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyEcbMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import org.junit.Test;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyEcbMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesSymmetricKeyEcbMode.java
@@ -1,21 +1,21 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class EncryptStringWithAesSymmetricKeyEcbMode extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String plainKey = "1234567890123456";
-		
-		String result = SymmetricEncryption.encryptString(input, plainKey, "AES", "", "SunJCE");
+    @Test
+    public void encryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        final String plainKey = "1234567890123456";
 
-		Assert.assertTrue(result.equals("222-157-20-54-132-99-46-30-73-43-253-148-61-155-86-141-51-56-40-42-31-168-189-56-236-102-58-237-175-171-9-87"));
-	}
+        final String result = SymmetricEncryption.encryptString(input, plainKey, "AES", "", "SunJCE");
+
+        assertEquals("222-157-20-54-132-99-46-30-73-43-253-148-61-155-86-141-51-56-40-42-31-168-189-56-236-102-58-237-175-171-9-87", result);
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyAndDefaultProviderCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyAndDefaultProviderCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyAndDefaultProviderCbcMode.java
@@ -2,25 +2,25 @@ package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class EncryptStringWithAesWrongSymmetricKeyAndDefaultProviderCbcMode extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesWrongSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String plainKey = "12345678901234567";
-		String iv = Hash.hashString("initialization vector", "MD5", "");		
+    @Test
+    public void encryptStringWithAesWrongSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        final String plainKey = "12345678901234567";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		try {
-			String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_cryptoKey));
-		}
-	}
+        try {
+            final String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_cryptoKey));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyCbcMode.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyCbcMode.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAesWrongSymmetricKeyCbcMode.java
@@ -2,25 +2,25 @@ package ro.kuberam.libs.java.crypto.encrypt;
 
 import ro.kuberam.libs.java.crypto.ErrorMessages;
 import ro.kuberam.libs.java.crypto.digest.Hash;
-import ro.kuberam.libs.java.crypto.encrypt.SymmetricEncryption;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertTrue;
+
 public class EncryptStringWithAesWrongSymmetricKeyCbcMode extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesWrongSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String plainKey = "12345678901234567";
-		String iv = Hash.hashString("initialization vector", "MD5", "");		
+    @Test
+    public void encryptStringWithAesWrongSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        final String plainKey = "12345678901234567";
+        final String iv = Hash.hashString("initialization vector", "MD5", "");
 
-		try {
-			String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
-			Assert.assertTrue(false);
-		} catch (Exception e) {
-			Assert.assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_cryptoKey));
-		}
-	}
+        try {
+            final String result = SymmetricEncryption.encryptString(input, plainKey, "AES/CBC/PKCS5Padding", iv, "SunJCE");
+            assertTrue(false);
+        } catch (final Exception e) {
+            assertTrue(e.getLocalizedMessage().equals(ErrorMessages.error_cryptoKey));
+        }
+    }
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAymmetricKey.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAymmetricKey.java
@@ -1,22 +1,27 @@
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 public class EncryptStringWithAymmetricKey extends BaseTest {
 
-	@Test
-	public void encryptStringWithAesSymmetricKey() throws Exception {
-		String input = "Short string for tests.";
-		String publicKey = IOUtils.toString(getClass().getResourceAsStream("../rsa-public-key.pub"));
+    @Test
+    public void encryptStringWithAesSymmetricKey() throws Exception {
+        final String input = "Short string for tests.";
+        try (final InputStream is = getClass().getResourceAsStream("../rsa-public-key.pub")) {
+            final String publicKey = IOUtils.toString(is, UTF_8);
 
-		String result = AsymmetricEncryption.encryptString(input, publicKey,
-				"RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
+            final String result = AsymmetricEncryption.encryptString(input, publicKey,
+                    "RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
 
-		System.out.println(result);
-	}
+            System.out.println(result);
+        }
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAymmetricKey.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/encrypt/EncryptStringWithAymmetricKey.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.encrypt;
 
 import org.apache.commons.io.IOUtils;

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/AddProviderTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/AddProviderTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 import javax.xml.stream.FactoryConfigurationError;

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/AddProviderTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/AddProviderTest.java
@@ -8,19 +8,19 @@ import ro.kuberam.tests.junit.BaseTest;
 
 public class AddProviderTest extends BaseTest {
 
-	@Test
-	public void addProvider() throws FactoryConfigurationError, Exception {
-		
-		String input = "Short string for tests.";
-	
+    @Test
+    public void addProvider() throws FactoryConfigurationError, Exception {
+
+        final String input = "Short string for tests.";
+
 //		String result2 = Hash.hashString(input, "SHA-256", "BC");
 //		
 //		System.out.println(result2);
 //
 //		Assert.assertTrue(result2
 //				.equals("E+B0JzLRgxm2+1rB8qIZoQ2Qn+JLxwJCWORv46fKhMM="));
-		
-		
-	}
+
+
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/ListProvidersTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/ListProvidersTest.java
@@ -3,20 +3,20 @@ package ro.kuberam.libs.java.crypto.providers;
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.transform.stream.StreamResult;
 
-import org.junit.Assert;
 import org.junit.Test;
 
-import ro.kuberam.libs.java.crypto.providers.ListProviders;
 import ro.kuberam.tests.junit.BaseTest;
+
+import static org.junit.Assert.assertTrue;
 
 public class ListProvidersTest extends BaseTest {
 
-	@Test
-	public void listProviders() throws FactoryConfigurationError, Exception {
-		StreamResult providers = ListProviders.listProviders();
-		String providersString = providers.getWriter().toString();
-		System.out.println(prettyPrintXmlString(providersString));
-		Assert.assertTrue(providersString.contains("SunJCE"));
-	}
+    @Test
+    public void listProviders() throws FactoryConfigurationError, Exception {
+        final StreamResult providers = ListProviders.listProviders();
+        final String providersString = providers.getWriter().toString();
+        System.out.println(prettyPrintXmlString(providersString));
+        assertTrue(providersString.contains("SunJCE"));
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/ListProvidersTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/ListProvidersTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 import javax.xml.stream.FactoryConfigurationError;

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/ListServicesTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/ListServicesTest.java
@@ -11,131 +11,135 @@ import ro.kuberam.tests.junit.BaseTest;
 
 public class ListServicesTest extends BaseTest {
 
-	// @Test
-	// public void listServices() throws XMLStreamException,
-	// FactoryConfigurationError {
-	// StreamResult providers = ListProviders.listProviders();
-	// String providersString = providers.getWriter().toString();
-	// System.out.println(providersString);
-	// Assert.assertTrue(providersString.contains("base64"));
-	// }
+    // @Test
+    // public void listServices() throws XMLStreamException,
+    // FactoryConfigurationError {
+    // StreamResult providers = ListProviders.listProviders();
+    // String providersString = providers.getWriter().toString();
+    // System.out.println(providersString);
+    // Assert.assertTrue(providersString.contains("base64"));
+    // }
 
-	private static String[] getServiceTypes() {
+    private static String[] getServiceTypes() {
 
-		Set result = new HashSet();
+        final Set<String> result = new HashSet<>();
 
-		// All providers
-		Provider[] providers = Security.getProviders();
-		for (int i = 0; i < providers.length; i++) {
+        // All providers
+        final Provider[] providers = Security.getProviders();
+        for (int i = 0; i < providers.length; i++) {
 
-			// Get services provided by each provider
-			Set keys = providers[i].keySet();
+            // Get services provided by each provider
+            final Set<Object> keys = providers[i].keySet();
 
-			for (Iterator it = keys.iterator(); it.hasNext();) {
+            for (final Iterator it = keys.iterator(); it.hasNext(); ) {
 
-				String key = (String) it.next();
-				key = key.split(" ")[0];
+                String key = (String) it.next();
+                key = key.split(" ")[0];
 
-				if (key.startsWith("Alg.Alias")) {
-					// Strip the alias
-					key = key.substring(10);
-				}
+                if (key.startsWith("Alg.Alias")) {
+                    // Strip the alias
+                    key = key.substring(10);
+                }
 
-				int ix = key.indexOf('.');
-				result.add(key.substring(0, ix));
-			}
+                final int ix = key.indexOf('.');
+                result.add(key.substring(0, ix));
+            }
 
-		}
+        }
 
-		return (String[]) result.toArray(new String[result.size()]);
+        return result.toArray(new String[result.size()]);
 
-	}
+    }
 
-	/**
-	 * * This method returns the available implementations for a given service *
-	 * type. * * @param serviceType * A String object that represents a
-	 * particular service type * @return String[] object that is a list of all
-	 * available * service type implementations.
-	 */
-	private static String[] getCryptoImpls(String serviceType) {
+    /**
+     * * This method returns the available implementations for a given service *
+     * type. * * @param serviceType * A String object that represents a
+     * particular service type * @return String[] object that is a list of all
+     * available * service type implementations.
+     */
+    private static String[] getCryptoImpls(final String serviceType) {
 
-		Set result = new HashSet();
+        final Set<String> result = new HashSet<>();
 
-		// All providers
-		Provider[] providers = Security.getProviders();
-		for (int i = 0; i < providers.length; i++) {
+        // All providers
+        final Provider[] providers = Security.getProviders();
+        for (int i = 0; i < providers.length; i++) {
 
-			// Get services provided by each provider
-			Set keys = providers[i].keySet();
+            // Get services provided by each provider
+            final Set<Object> keys = providers[i].keySet();
 
-			for (Iterator it = keys.iterator(); it.hasNext();) {
+            for (final Iterator it = keys.iterator(); it.hasNext(); ) {
 
-				String key = (String) it.next();
+                String key = (String) it.next();
 
-				key = key.split(" ")[0];
+                key = key.split(" ")[0];
 
-				if (key.startsWith(serviceType + ".")) {
-					result.add(key.substring(serviceType.length() + 1));
-				} else if (key.startsWith("Alg.Alias." + serviceType + ".")) {
-					// This is an alias
-					result.add(key.substring(serviceType.length() + 11));
-				}
+                if (key.startsWith(serviceType + ".")) {
+                    result.add(key.substring(serviceType.length() + 1));
+                } else if (key.startsWith("Alg.Alias." + serviceType + ".")) {
+                    // This is an alias
+                    result.add(key.substring(serviceType.length() + 11));
+                }
 
-			}
+            }
 
-		}
+        }
 
-		return (String[]) result.toArray(new String[result.size()]);
+        return result.toArray(new String[result.size()]);
 
-	}
+    }
 
-	/** * Print all Service Types (sorted) to STDOUT. */
-	private static void listServiceTypes() {
+    /**
+     * Print all Service Types (sorted) to STDOUT.
+     */
+    private static void listServiceTypes() {
 
-		System.out.println();
-		System.out.println("Service Types");
-		System.out.println("-------------");
+        System.out.println();
+        System.out.println("Service Types");
+        System.out.println("-------------");
 
-		String[] serviceTypes = getServiceTypes();
-		Arrays.sort(serviceTypes);
+        final String[] serviceTypes = getServiceTypes();
+        Arrays.sort(serviceTypes);
 
-		for (int i = 0; i < serviceTypes.length; i++) {
-			System.out.println("  - " + serviceTypes[i]);
-		}
-		System.out.println();
+        for (int i = 0; i < serviceTypes.length; i++) {
+            System.out.println("  - " + serviceTypes[i]);
+        }
+        System.out.println();
 
-	}
+    }
 
-	/** * Print all Service Type Implementations (sorted) to STDOUT. */
-	private static void listCryptoImpls() {
+    /**
+     * Print all Service Type Implementations (sorted) to STDOUT.
+     */
+    private static void listCryptoImpls() {
 
-		System.out.println();
-		System.out.println("Service Type Implementations");
-		System.out.println("----------------------------");
+        System.out.println();
+        System.out.println("Service Type Implementations");
+        System.out.println("----------------------------");
 
-		String[] serviceTypes = getServiceTypes();
-		Arrays.sort(serviceTypes);
+        String[] serviceTypes = getServiceTypes();
+        Arrays.sort(serviceTypes);
 
-		for (int i = 0; i < serviceTypes.length; i++) {
+        for (int i = 0; i < serviceTypes.length; i++) {
 
-			System.out.println();
-			System.out.println("  - " + serviceTypes[i]);
+            System.out.println();
+            System.out.println("  - " + serviceTypes[i]);
 
-			String[] serviceTypeImpls = getCryptoImpls(serviceTypes[i]);
-			Arrays.sort(serviceTypeImpls);
+            final String[] serviceTypeImpls = getCryptoImpls(serviceTypes[i]);
+            Arrays.sort(serviceTypeImpls);
 
-			for (int j = 0; j < serviceTypeImpls.length; j++) {
-				System.out.println("      " + serviceTypeImpls[j]);
-			}
+            for (int j = 0; j < serviceTypeImpls.length; j++) {
+                System.out.println("      " + serviceTypeImpls[j]);
+            }
 
-		}
-		System.out.println();
+        }
+        System.out.println();
 
-	}
+    }
 
-	public static void main(String[] args) {
-		listServiceTypes();
-		listCryptoImpls();
-	}
+    public static void main(final String[] args) {
+        listServiceTypes();
+        listCryptoImpls();
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/providers/ListServicesTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/providers/ListServicesTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.providers;
 
 import java.security.Provider;

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexStringPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexStringPerformanceTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.utils;
 
 import java.io.IOException;

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexStringPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/ByteArray2HexStringPerformanceTest.java
@@ -1,257 +1,221 @@
 package ro.kuberam.libs.java.crypto.utils;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Formatter;
 
 import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static junit.framework.TestCase.assertEquals;
+
 public class ByteArray2HexStringPerformanceTest extends BaseTest {
 
-	private static File tempFile;
-	private static byte[] tempByteArray;
+    private static Path tempFile;
+    private static byte[] tempByteArray;
 
-	@BeforeClass
-	public static void initialize() throws IOException {
-		tempFile = generate5MbTempFile();
-		InputStream is = new FileInputStream(tempFile);
-		
-		//
-		ByteArrayOutputStream bos = new ByteArrayOutputStream();
-		int next = is.read();
-		while (next > -1) {
-		    bos.write(next);
-		    next = is.read();
-		}
-		bos.flush();		
-		tempByteArray = bos.toByteArray();
-	}
+    @BeforeClass
+    public static void initialize() throws IOException {
+        tempFile = generate5MbTempFile().toPath();
+        tempByteArray = Files.readAllBytes(tempFile);
+    }
 
-	
-	@Test
-	public void hexCharsTest() throws Exception {
 
-		final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
-		
-		int tempByteArrayLength = tempByteArray.length;
+    @Test
+    public void hexCharsTest() throws Exception {
+        final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
+        final int tempByteArrayLength = tempByteArray.length;
 
-		char[] chars = new char[2 * tempByteArrayLength];
-        for (int i = 0; i < tempByteArrayLength; ++i)
-        {
+        final char[] chars = new char[2 * tempByteArrayLength];
+        for (int i = 0; i < tempByteArrayLength; ++i) {
             chars[2 * i] = HEX_CHARS[(tempByteArray[i] & 0xF0) >>> 4];
             chars[2 * i + 1] = HEX_CHARS[tempByteArray[i] & 0x0F];
         }
-        String result = new String(chars);
-        Assert.assertTrue(result.length() == 10400000);
-	}	
+        final String result = new String(chars);
+        assertEquals(10400000, result.length());
+    }
 
-	@Test
-	public void formatterTest() throws Exception {
-
-		Formatter formatter = new Formatter();
-		for (byte b : tempByteArray) {
-			formatter.format("%02x", b);
-		}
-
-		String result = formatter.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void stringBufferTest1() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-
-		StringBuffer strbuf = new StringBuffer(tempByteArrayLength * 2);
-
-        for(int i=0; i< tempByteArrayLength; i++)
-        {
-                if(((int) tempByteArray[i] & 0xff) < 0x10)
-                        strbuf.append("0");
-                strbuf.append(Long.toString((int) tempByteArray[i] & 0xff, 16));
+    @Test
+    public void formatterTest() throws Exception {
+        final Formatter formatter = new Formatter();
+        for (final byte b : tempByteArray) {
+            formatter.format("%02x", b);
         }
 
-		String result = strbuf.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void stringBufferTest2() throws Exception {
-		
-		StringBuffer sb = new StringBuffer();
-		for (byte b : tempByteArray) {
-			sb.append(Integer.toHexString((int) (b & 0xff)));
-		}
+        final String result = formatter.toString();
+        assertEquals(10400000, result.length());
+    }
 
-		String result = sb.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void charArrayTest() throws Exception {
-		
-		char[] hexDigits = "0123456789abcdef".toCharArray();
-		char[] byteToHexPair = new char[16 * 16 * 2];
-		for (int i = 0, o = 0; i < 256; ++i) {
-			byteToHexPair[o++] = hexDigits[i >>> 4];
-		    byteToHexPair[o++] = hexDigits[i & 15];
-		}
-		
-		int tempByteArrayLength = tempByteArray.length;
-		  char[] chars = new char[2 * tempByteArrayLength];
-		  for (int i = 0, o = 0; i < tempByteArrayLength; ++i) {
-		    int index = tempByteArray[i];
-		    chars[o++] = byteToHexPair[index++];
-		    chars[o++] = byteToHexPair[index];
-		  }
+    @Test
+    public void stringBuilderTest1() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
 
-		String result = new String(chars);
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void hexArrayTest() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-		
-		char[] hexArray = {'0','1','2','3','4','5','6','7','8','9','A','B','C','D','E','F'};
-		char[] hexChars = new char[tempByteArrayLength * 2];
-		int v;
-		for ( int j = 0; j < tempByteArrayLength; j++ ) {
-			v = tempByteArray[j] & 0xFF;
-			hexChars[j*2] = hexArray[v/16];
-			hexChars[j*2 + 1] = hexArray[v%16];
-		}
-		 
-		String result = new String(hexChars);
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void stringBuilder1Test() throws Exception {
-		
-		StringBuilder sb = new StringBuilder();
-	    for (byte b : tempByteArray) {
-	        sb.append(String.format("%1$02X", b));
-	    }
-		 
-		String result = sb.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}	
-	
-	@Test
-	public void stringBuilder2Test() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-		
-	    StringBuilder sb = new StringBuilder(tempByteArrayLength*2);
-	    for(byte b: tempByteArray) {
-	    	sb.append(Integer.toHexString(b+0x800).substring(1));
-	    }
-	    
-		String result = sb.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void stringBuilder3Test() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-		
-		String digits = "0123456789abcdef";
-		
-		StringBuilder sb = new StringBuilder(tempByteArrayLength * 2);
-		for (byte b : tempByteArray) {
-			int bi = b & 0xff;
-			sb.append(digits.charAt(bi >> 4));
-			sb.append(digits.charAt(bi & 0xf));
-		}
-	    
-		String result = sb.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void stringBuilder4Test() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-		
-		StringBuffer hexString = new StringBuffer();
-		for (int i = 0; i < tempByteArrayLength; i++) {
-		    String hexByte = Integer.toHexString(0xFF & tempByteArray[i]);
-		    int numDigits = 2 - hexByte.length();
-		    while (numDigits-- > 0) {
-		        hexString.append('0');
-		    }
-		    hexString.append(hexByte);
-		}
+        final StringBuilder strbuf = new StringBuilder(tempByteArrayLength * 2);
 
-		String result = hexString.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void hexBinaryAdapterTest() throws Exception {
-		
-		String result = (new HexBinaryAdapter()).marshal(tempByteArray);
+        for (int i = 0; i < tempByteArrayLength; i++) {
+            if (((int) tempByteArray[i] & 0xff) < 0x10) {
+                strbuf.append("0");
+            }
+            strbuf.append(Long.toString((int) tempByteArray[i] & 0xff, 16));
+        }
 
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	public void integer2Test() throws Exception {
-		
-		int tempByteArrayLength = tempByteArray.length;
-		
-		StringBuffer hexString = new StringBuffer();
+        final String result = strbuf.toString();
+        assertEquals(10400000, result.length());
+    }
 
-		for (int i = 0; i < tempByteArrayLength; i++) {
-		    int temp=0xFF & tempByteArray[i];
-		    String s=Integer.toHexString(temp);
-		    if(temp<=0x0F){
-		        s="0"+s;
-		    }
-		    hexString.append(s);
-		}
-		
-		String result = hexString.toString();
-		Assert.assertTrue(result.length() == 10400000);
-	}	
-	
-	@Test
-	@Ignore("too slow, took hours and didn't finish")	
-	public void integer1Test() throws Exception {
-		
-		int tempByteArrayLengthQuartered = tempByteArray.length / 4;
+    @Test
+    public void stringBuilderTest2() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : tempByteArray) {
+            sb.append(Integer.toHexString((int) (b & 0xff)));
+        }
 
-		String result = "";
-		for(int i = 0; i < tempByteArrayLengthQuartered; i++){
-		  int ii = i * 4;
-		  int inty = tempByteArray[ii] + tempByteArray[ii+1]*0xff + tempByteArray[ii+2]*0xffff + tempByteArray[ii+3]*0xffffff;
-		  result = Integer.toHexString(inty) + result;
-		}
+        final String result = sb.toString();
+        assertEquals(10400000, result.length());
+    }
 
-		Assert.assertTrue(result.length() == 10400000);
-	}
-	
-	@Test
-	@Ignore("too slow")
-	public void stringFormatterTest() throws Exception {
-		
-		byte[] a = { 0x40, 0x00, 0x39, 0x00 };
+    @Test
+    public void charArrayTest() throws Exception {
+        final char[] hexDigits = "0123456789abcdef".toCharArray();
+        final char[] byteToHexPair = new char[16 * 16 * 2];
+        for (int i = 0, o = 0; i < 256; ++i) {
+            byteToHexPair[o++] = hexDigits[i >>> 4];
+            byteToHexPair[o++] = hexDigits[i & 15];
+        }
 
-		String result = String.format("%0128x", new BigInteger(1, tempByteArray));
-	}
+        final int tempByteArrayLength = tempByteArray.length;
+        final char[] chars = new char[2 * tempByteArrayLength];
+        for (int i = 0, o = 0; i < tempByteArrayLength; ++i) {
+            int index = tempByteArray[i];
+            chars[o++] = byteToHexPair[index++];
+            chars[o++] = byteToHexPair[index];
+        }
+
+        final String result = new String(chars);
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void hexArrayTest() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
+        final char[] hexArray = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+        final char[] hexChars = new char[tempByteArrayLength * 2];
+        int v;
+        for (int j = 0; j < tempByteArrayLength; j++) {
+            v = tempByteArray[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v / 16];
+            hexChars[j * 2 + 1] = hexArray[v % 16];
+        }
+
+        final String result = new String(hexChars);
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void stringBuilder1Test() throws Exception {
+        final StringBuilder sb = new StringBuilder();
+        for (final byte b : tempByteArray) {
+            sb.append(String.format("%1$02X", b));
+        }
+
+        final String result = sb.toString();
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void stringBuilder2Test() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
+        final StringBuilder sb = new StringBuilder(tempByteArrayLength * 2);
+        for (final byte b : tempByteArray) {
+            sb.append(Integer.toHexString(b + 0x800).substring(1));
+        }
+
+        final String result = sb.toString();
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void stringBuilder3Test() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
+        final String digits = "0123456789abcdef";
+        final StringBuilder sb = new StringBuilder(tempByteArrayLength * 2);
+        for (final byte b : tempByteArray) {
+            int bi = b & 0xff;
+            sb.append(digits.charAt(bi >> 4));
+            sb.append(digits.charAt(bi & 0xf));
+        }
+
+        final String result = sb.toString();
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void stringBuilder4Test() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
+        final StringBuilder hexString = new StringBuilder();
+        for (int i = 0; i < tempByteArrayLength; i++) {
+            final String hexByte = Integer.toHexString(0xFF & tempByteArray[i]);
+            int numDigits = 2 - hexByte.length();
+            while (numDigits-- > 0) {
+                hexString.append('0');
+            }
+            hexString.append(hexByte);
+        }
+
+        final String result = hexString.toString();
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void hexBinaryAdapterTest() throws Exception {
+        final String result = new HexBinaryAdapter().marshal(tempByteArray);
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    public void integer2Test() throws Exception {
+        final int tempByteArrayLength = tempByteArray.length;
+        final StringBuilder hexString = new StringBuilder();
+        for (int i = 0; i < tempByteArrayLength; i++) {
+            final int temp = 0xFF & tempByteArray[i];
+            String s = Integer.toHexString(temp);
+            if (temp <= 0x0F) {
+                s = "0" + s;
+            }
+            hexString.append(s);
+        }
+
+        final String result = hexString.toString();
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    @Ignore("too slow, took hours and didn't finish")
+    public void integer1Test() throws Exception {
+        final int tempByteArrayLengthQuartered = tempByteArray.length / 4;
+
+        String result = "";
+        for (int i = 0; i < tempByteArrayLengthQuartered; i++) {
+            final int ii = i * 4;
+            final int inty = tempByteArray[ii] + tempByteArray[ii + 1] * 0xff + tempByteArray[ii + 2] * 0xffff + tempByteArray[ii + 3] * 0xffffff;
+            result = Integer.toHexString(inty) + result;
+        }
+
+        assertEquals(10400000, result.length());
+    }
+
+    @Test
+    @Ignore("too slow")
+    public void stringFormatterTest() throws Exception {
+        final byte[] a = {0x40, 0x00, 0x39, 0x00};
+        final String result = String.format("%0128x", new BigInteger(1, tempByteArray));
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/InputStream2ByteArrayPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/InputStream2ByteArrayPerformanceTest.java
@@ -1,42 +1,42 @@
 package ro.kuberam.libs.java.crypto.utils;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import ro.kuberam.tests.junit.BaseTest;
 
+import static org.junit.Assert.assertEquals;
+
 public class InputStream2ByteArrayPerformanceTest extends BaseTest {
 
-	private static File tempFile;
-	private static InputStream tempFileIs;
+    private static Path tempFile;
 
-	@Before
-	public void initialize() throws IOException {
-		tempFile = generate5MbTempFile();
-		tempFileIs = new FileInputStream(tempFile);
+    @Before
+    public void initialize() throws IOException {
+        tempFile = generate5MbTempFile().toPath();
+    }
 
-	}
+    @Test
+    public void byteArrayOutputStreamTest() throws Exception {
 
-	@Test
-	public void byteArrayOutputStreamTest() throws Exception {
+        try (final InputStream is = Files.newInputStream(tempFile);
+             final ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            int next = is.read();
+            while (next > -1) {
+                baos.write(next);
+                next = is.read();
+            }
+            baos.flush();
+            final byte[] byteArray = baos.toByteArray();
 
-		ByteArrayOutputStream baos = new ByteArrayOutputStream();
-		int next = tempFileIs.read();
-		while (next > -1) {
-			baos.write(next);
-			next = tempFileIs.read();
-		}
-		baos.flush();
-		byte[] byteArray = baos.toByteArray();
-
-		Assert.assertTrue(byteArray.length == 5200000);
-	}
+            assertEquals(5200000, byteArray.length);
+        }
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/InputStream2ByteArrayPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/InputStream2ByteArrayPerformanceTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.utils;
 
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/String2InputStreamPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/String2InputStreamPerformanceTest.java
@@ -3,7 +3,6 @@ package ro.kuberam.libs.java.crypto.utils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.BeforeClass;
@@ -12,17 +11,19 @@ import org.junit.Test;
 import ro.kuberam.tests.junit.BaseTest;
 
 public class String2InputStreamPerformanceTest extends BaseTest {
-	
-	private static String tempString;
 
-	@BeforeClass
-	public static void initialize() throws IOException {		
-		tempString = generate5MbTempString();
-	}	
+    private static String tempString;
 
-	@Test
-	public void test() {
-        InputStream is = new ByteArrayInputStream(tempString.getBytes(StandardCharsets.UTF_8));
-	}
+    @BeforeClass
+    public static void initialize() throws IOException {
+        tempString = generate5MbTempString();
+    }
+
+    @Test
+    public void test() throws IOException {
+        try (final InputStream is = new ByteArrayInputStream(tempString.getBytes(StandardCharsets.UTF_8))) {
+
+        }
+    }
 
 }

--- a/src/test/java/ro/kuberam/libs/java/crypto/utils/String2InputStreamPerformanceTest.java
+++ b/src/test/java/ro/kuberam/libs/java/crypto/utils/String2InputStreamPerformanceTest.java
@@ -1,3 +1,22 @@
+/**
+ * EXPath Cryptographic Module
+ * Java Library providing an EXPath Cryptographic Module
+ * Copyright (C) 2015 Kuberam
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2.1
+ * of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation,
+ * Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ */
 package ro.kuberam.libs.java.crypto.utils;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
Apart from the general code cleanup, the changes when combined with the eXist EXPath Crypto module should result in a reduction of 66% memory use for Hash and HMAC functions.

Instead of making various copies in-memory of binary data, we now operate directly on the binary streams provided by eXist-db.